### PR TITLE
Control zero humidity in thermo computations

### DIFF
--- a/src/earthkit/meteo/thermo/array/thermo.py
+++ b/src/earthkit/meteo/thermo/array/thermo.py
@@ -13,6 +13,10 @@ import numpy as np
 from earthkit.meteo import constants
 
 
+def _valid_number(x):
+    return x is not None and not np.isnan(x)
+
+
 def celsius_to_kelvin(t):
     """Converts temperature values from Celsius to Kelvin.
 
@@ -259,9 +263,21 @@ class _EsComp:
         elif phase == "ice":
             return self._es_ice_slope(t)
 
-    def t_from_es(self, es):
-        v = np.log(es / self.c1)
-        return (v * self.c4w - self.c3w * self.t0) / (v - self.c3w)
+    def t_from_es(self, es, eps=1e-8, out=None):
+        def _comp(x):
+            x = x / self.c1
+            x = np.log(x)
+            return (x * self.c4w - self.c3w * self.t0) / (x - self.c3w)
+
+        if out is not None:
+            v = np.asarray(es)
+            z_mask = v < eps
+            v_mask = ~z_mask
+            v[v_mask] = _comp(v[v_mask])
+            v[z_mask] = out
+            return v
+        else:
+            return _comp(es)
 
     def _es_water(self, t):
         return self.c1 * np.exp(self.c3w * (t - self.t0) / (t - self.c4w))
@@ -556,13 +572,21 @@ def saturation_specific_humidity_slope(t, p, es=None, es_slope=None, phase="mixe
     return constants.epsilon * es_slope * p / v
 
 
-def temperature_from_saturation_vapour_pressure(es):
-    r"""Computes the temperature from saturation vapour pressure.
+def temperature_from_saturation_vapour_pressure(es, eps=1e-8, out=None):
+    r"""Compute the temperature from saturation vapour pressure.
 
     Parameters
     ----------
     es: ndarray
         :func:`saturation_vapour_pressure` (Pa)
+    eps: number
+        If ``out`` is not None, return ``out`` when ``es`` < ``eps``. If out
+        is None, ``eps`` is ignored and return np.nan for ``es`` values very
+        close to zero.
+    out: number or None
+        If not None, return ``out`` when ``es`` < ``eps``. If None, ``eps`` is
+        ignored and return np.nan for ``es`` values very close to zero.
+
 
     Returns
     -------
@@ -575,7 +599,7 @@ def temperature_from_saturation_vapour_pressure(es):
     phase ``es`` was computed to.
 
     """
-    return _EsComp().t_from_es(es)
+    return _EsComp().t_from_es(es, eps=eps, out=out)
 
 
 def relative_humidity_from_dewpoint(t, td):
@@ -750,8 +774,8 @@ def specific_humidity_from_relative_humidity(t, r, p):
     return specific_humidity_from_vapour_pressure(e, p)
 
 
-def dewpoint_from_relative_humidity(t, r):
-    r"""Computes the dewpoint temperature from relative humidity.
+def dewpoint_from_relative_humidity(t, r, eps=1e-8, out=None):
+    r"""Compute the dewpoint temperature from relative humidity.
 
     Parameters
     ----------
@@ -759,11 +783,18 @@ def dewpoint_from_relative_humidity(t, r):
         Temperature (K)
     r: ndarray
         Relative humidity (%)
+    eps: number
+        If ``out`` is not None, return ``out`` when ``r`` < ``eps``.
+        If out is None, ``eps`` is ignored and return np.nan for ``q``
+        values very close to zero.
+    out: number or None
+        If not None, return ``out`` when ``r`` < ``eps``. If None, ``eps`` is
+        ignored and return np.nan for ``r`` values very close to zero.
 
     Returns
     -------
     ndarray
-        Dewpoint (K)
+        Dewpoint temperature (K)
 
 
     The computation starts with determining the the saturation vapour pressure over
@@ -782,11 +813,23 @@ def dewpoint_from_relative_humidity(t, r):
     equations used in :func:`saturation_vapour_pressure`.
 
     """
+    # by masking upfront we avoid RuntimeWarning when calling log() in
+    # the computation of td when r is very small
+    if out is not None:
+        r = np.asarray(r)
+        mask = r < eps
+        r[mask] = np.nan
+
     es = saturation_vapour_pressure(t, phase="water") * r / 100.0
-    return temperature_from_saturation_vapour_pressure(es)
+    td = temperature_from_saturation_vapour_pressure(es)
+
+    if out is not None and not np.isnan(out):
+        td[mask] = out
+
+    return td
 
 
-def dewpoint_from_specific_humidity(q, p):
+def dewpoint_from_specific_humidity(q, p, eps=1e-8, out=None):
     r"""Computes the dewpoint temperature from specific humidity.
 
     Parameters
@@ -795,11 +838,20 @@ def dewpoint_from_specific_humidity(q, p):
         Specific humidity (kg/kg)
     p: ndarray
         Pressure (Pa)
+    eps: number
+        As an intermediate result the saturation vapour pressure
+        (``es``) is computed (see details below). If ``out`` is not
+        None, return ``out`` when ``es`` < ``eps``. If out is None,
+        ``eps`` is ignored and return np.nan for ``es`` values very
+        close to zero.
+    out: number or None
+        If not None, return ``out`` when ``es`` < ``eps``. If None, ``eps`` is
+        ignored and return np.nan for ``es`` values very close to zero.
 
     Returns
     -------
     ndarray
-        Dewpoint (K)
+        Dewpoint temperature (K)
 
 
     The computation starts with determining the the saturation vapour pressure over
@@ -819,7 +871,20 @@ def dewpoint_from_specific_humidity(q, p):
     used in :func:`saturation_vapour_pressure`.
 
     """
-    return temperature_from_saturation_vapour_pressure(vapour_pressure_from_specific_humidity(q, p))
+    # by masking upfront we avoid RuntimeWarning when calling log() in
+    # the computation of td when q is very small
+    if out is not None:
+        q = np.asarray(q)
+        mask = q < eps
+        q[mask] = np.nan
+
+    es = vapour_pressure_from_specific_humidity(q, p)
+    td = temperature_from_saturation_vapour_pressure(es)
+
+    if out is not None and not np.isnan(out):
+        td[mask] = out
+
+    return td
 
 
 def virtual_temperature(t, q):
@@ -828,7 +893,7 @@ def virtual_temperature(t, q):
     Parameters
     ----------
     t: number or ndarray
-        Temperature (K)
+        Temperature (K)s
     q: number or ndarray
         Specific humidity (kg/kg)
 

--- a/src/earthkit/meteo/thermo/array/thermo.py
+++ b/src/earthkit/meteo/thermo/array/thermo.py
@@ -824,6 +824,7 @@ def dewpoint_from_relative_humidity(t, r, eps=1e-8, out=None):
     td = temperature_from_saturation_vapour_pressure(es)
 
     if out is not None and not np.isnan(out):
+        td = np.asarray(td)
         td[mask] = out
 
     return td
@@ -880,6 +881,7 @@ def dewpoint_from_specific_humidity(q, p, eps=1e-8, out=None):
     td = temperature_from_saturation_vapour_pressure(es)
 
     if out is not None and not np.isnan(out):
+        td = np.asarray(td)
         td[mask] = out
 
     return td

--- a/src/earthkit/meteo/thermo/array/thermo.py
+++ b/src/earthkit/meteo/thermo/array/thermo.py
@@ -785,7 +785,7 @@ def dewpoint_from_relative_humidity(t, r, eps=1e-8, out=None):
         Relative humidity (%)
     eps: number
         If ``out`` is not None, return ``out`` when ``r`` < ``eps``.
-        If out is None, ``eps`` is ignored and return np.nan for ``q``
+        If out is None, ``eps`` is ignored and return np.nan for ``r``
         values very close to zero.
     out: number or None
         If not None, return ``out`` when ``r`` < ``eps``. If None, ``eps`` is
@@ -839,14 +839,12 @@ def dewpoint_from_specific_humidity(q, p, eps=1e-8, out=None):
     p: ndarray
         Pressure (Pa)
     eps: number
-        As an intermediate result the saturation vapour pressure
-        (``es``) is computed (see details below). If ``out`` is not
-        None, return ``out`` when ``es`` < ``eps``. If out is None,
-        ``eps`` is ignored and return np.nan for ``es`` values very
-        close to zero.
+        If ``out`` is not None, return ``out`` when ``q`` < ``eps``.
+        If out is None, ``eps`` is ignored and return np.nan for ``q``
+        values very close to zero.
     out: number or None
-        If not None, return ``out`` when ``es`` < ``eps``. If None, ``eps`` is
-        ignored and return np.nan for ``es`` values very close to zero.
+        If not None, return ``out`` when ``q`` < ``eps``. If None, ``eps`` is
+        ignored and return np.nan for ``q`` values very close to zero.
 
     Returns
     -------

--- a/tests/thermo/test_thermo_array.py
+++ b/tests/thermo/test_thermo_array.py
@@ -485,6 +485,11 @@ def test_specific_humidity_from_relative_humidity():
             {"eps": 1e-3, "out": np.nan},
             [10, np.nan, np.nan],
         ),
+        (20.0, 52.5224541378, {}, 10.0),
+        (20.0, 0.0, {"eps": 1e-3, "out": thermo.array.celsius_to_kelvin(100)}, 100),
+        (20.0, 0.000001, {"eps": 1e-3, "out": thermo.array.celsius_to_kelvin(100)}, 100),
+        (20.0, 0.0, {"eps": 1e-3, "out": np.nan}, np.nan),
+        (20, 0.000001, {"eps": 1e-3, "out": np.nan}, np.nan),
     ],
 )
 def test_dewpoint_from_relative_humidity(t, r, kwargs, expected_values):
@@ -536,6 +541,11 @@ def test_dewpoint_from_relative_humidity(t, r, kwargs, expected_values):
             {"eps": 1e-3, "out": np.nan},
             [21.78907, np.nan, np.nan],
         ),
+        (0.0169461501, 967.508, {}, 21.78907),
+        (0.0, 967.5085, {"eps": 1e-3, "out": thermo.array.celsius_to_kelvin(100)}, 100),
+        (0.000001, 967.5085, {"eps": 1e-3, "out": thermo.array.celsius_to_kelvin(100)}, 100),
+        (0.0, 967.5085, {"eps": 1e-3, "out": np.nan}, np.nan),
+        (0.000001, 967.5085, {"eps": 1e-3, "out": np.nan}, np.nan),
     ],
 )
 def test_dewpoint_from_specific_humidity(q, p, kwargs, expected_values):


### PR DESCRIPTION
Fixes #20 

This PR adds the `eps` and `out` keyword arguments to 

- dewpoint_from_specific_humidity
- dewpoint_from_relative_humidity
- temperature_from_saturation_vapour_pressure

with the follwoing meaning (e.g. for `dewpoint_from_specific_humidity`):
```rst
def dewpoint_from_specific_humidity(q, p, eps=1e-8, out=None):
...
eps: number
        If ``out`` is not None, return ``out`` when ``q`` < ``eps``.
        If out is None, ``eps`` is ignored and return np.nan for ``q``
        values very close to zero.
out: number or None
        If not None, return ``out`` when ``q`` < ``eps``. If None, ``eps`` is
        ignored and return np.nan for ``q`` values very close to zero.
```

Examples:

```python
>>> from earthkit.meteo.thermo import dewpoint_from_specific_humidity
>>> dewpoint_from_specific_humidity(0., 10000.)
np.nan
>>> dewpoint_from_specific_humidity(0., 10000, out=100)
100
>>> dewpoint_from_specific_humidity(1e-6, 10000, eps=1e-5, out=100)
100
```