### PR TITLE
Compute geometric and geopotential height

### DIFF
--- a/src/earthkit/meteo/vertical/array/vertical.py
+++ b/src/earthkit/meteo/vertical/array/vertical.py
@@ -217,7 +217,8 @@ def geopotential_height_from_geopotential(z):
 
         gh = \frac{z}{g}
 
-    where :math:`g` is the gravitational acceleration on the surface of the Earth (m/s2)
+    where :math:`g` is the gravitational acceleration on the surface of
+    the Earth (see :py:attr:`meteo.constants.g`)
     """
     h = z / constants.g
     return h
@@ -245,7 +246,7 @@ def geopotential_height_from_geometric_height(h, R_earth=constants.R_earth):
 
         gh = \frac{h\; R_{earth}}{R_{earth} + h}
 
-    where :math:`R_{earth}` is the average radius of the Earth (m)
+    where :math:`R_{earth}` is the average radius of the Earth (see :py:attr:`meteo.constants.R_earth`)
     """
     zh = h * R_earth / (R_earth + h)
     return zh
@@ -275,8 +276,9 @@ def geopotential_from_geometric_height(h, R_earth=constants.R_earth):
 
     where
 
-        * :math:`R_{earth}` is the average radius of the Earth (m)
-        * :math:`g` is the gravitational acceleration on the surface of the Earth (m/s2)
+        * :math:`R_{earth}` is the average radius of the Earth (see :py:attr:`meteo.constants.R_earth`)
+        * :math:`g` is the gravitational acceleration on the surface of
+          the Earth (see :py:attr:`meteo.constants.g`)
     """
     z = h * R_earth * constants.g / (R_earth + h)
     return z
@@ -304,9 +306,7 @@ def geometric_height_from_geopotential_height(gh, R_earth=constants.R_earth):
 
         h = \frac{R_{earth}\; gh}{R_{earth} - gh}
 
-    where
-
-        * :math:`R_{earth}` is the average radius of the Earth (m)
+    where :math:`R_{earth}` is the average radius of the Earth (see :py:attr:`meteo.constants.R_earth`)
     """
     h = R_earth * gh / (R_earth - gh)
     return h
@@ -336,8 +336,9 @@ def geometric_height_from_geopotential(z, R_earth=constants.R_earth):
 
     where
 
-        * :math:`R_{earth}` is the average radius of the Earth (m)
-        * :math:`g` is the gravitational acceleration on the surface of the Earth (m/s2)
+        * :math:`R_{earth}` is the average radius of the Earth (see :py:attr:`meteo.constants.R_earth`)
+        * :math:`g` is the gravitational acceleration on the surface of
+          the Earth (see :py:attr:`meteo.constants.g`)
     """
     z = z / constants.g
     h = R_earth * z / (R_earth - z)

--- a/src/earthkit/meteo/vertical/array/vertical.py
+++ b/src/earthkit/meteo/vertical/array/vertical.py
@@ -19,7 +19,7 @@ from earthkit.meteo import constants
 def pressure_at_model_levels(
     A: NDArray[Any], B: NDArray[Any], sp: Union[float, NDArray[Any]]
 ) -> Tuple[NDArray[Any], NDArray[Any], NDArray[Any], NDArray[Any]]:
-    r"""Computes:
+    r"""Compute
      - pressure at the model full- and half-levels
      - delta: depth of log(pressure) at full levels
      - alpha: alpha term #TODO: more descriptive information.
@@ -103,7 +103,7 @@ def pressure_at_model_levels(
 
 
 def relative_geopotential_thickness(alpha: NDArray[Any], q: NDArray[Any], T: NDArray[Any]) -> NDArray[Any]:
-    """Calculates the geopotential thickness w.r.t the surface on model full-levels.
+    """Calculate the geopotential thickness w.r.t the surface on model full-levels.
 
     Parameters
     ----------
@@ -131,7 +131,7 @@ def relative_geopotential_thickness(alpha: NDArray[Any], q: NDArray[Any], T: NDA
 def pressure_at_height_level(
     height: float, q: NDArray[Any], T: NDArray[Any], sp: NDArray[Any], A: NDArray[Any], B: NDArray[Any]
 ) -> Union[float, NDArray[Any]]:
-    """Calculates the pressure at a height level given in meters above surface.
+    """Calculate the pressure at a height level given in meters above surface.
     This is done by finding the model level above and below the specified height
     and interpolating the pressure.
 
@@ -195,3 +195,150 @@ def pressure_at_height_level(
     p_height[~mask] = p_full[above] + factor * (p_full[below] - p_full[above])
 
     return p_height
+
+
+def geopotential_height_from_geopotential(z):
+    r"""Compute geopotential height from geopotential.
+
+    Parameters
+    ----------
+    z : ndarray
+        Geopotential (m2/s2)
+
+    Returns
+    -------
+    ndarray
+        Geopotential height (m)
+
+
+    The computation is based on the following definition:
+
+    .. math::
+
+        gh = \frac{z}{g}
+
+    where :math:`g` is the gravitational acceleration on the surface of the Earth (m/s2)
+    """
+    h = z / constants.g
+    return h
+
+
+def geopotential_height_from_geometric_height(h, R_earth=constants.R_earth):
+    r"""Compute the geopotential height from geometric height.
+
+    Parameters
+    ----------
+    h : ndarray
+        Geometric height with respect to the sea level (m)
+    R_earth : float, optional
+        Average radius of the Earth (m)
+
+    Returns
+    -------
+    ndarray
+        Geopotential height (m)
+
+
+    The computation is based on the following formula:
+
+    .. math::
+
+        gh = \frac{h\; R_{earth}}{R_{earth} + h}
+
+    where :math:`R_{earth}` is the average radius of the Earth (m)
+    """
+    zh = h * R_earth / (R_earth + h)
+    return zh
+
+
+def geopotential_from_geometric_height(h, R_earth=constants.R_earth):
+    r"""Compute the geopotential from geometric height.
+
+    Parameters
+    ----------
+    h : ndarray
+        Geometric height with respect to the sea level (m)
+    R_earth : float, optional
+        Average radius of the Earth (m)
+
+    Returns
+    -------
+    ndarray
+        Geopotential (m2/s2)
+
+
+    The computation is based on the following formula:
+
+    .. math::
+
+        z = \frac{h\; g\; R_{earth}}{R_{earth} + h}
+
+    where
+
+        * :math:`R_{earth}` is the average radius of the Earth (m)
+        * :math:`g` is the gravitational acceleration on the surface of the Earth (m/s2)
+    """
+    z = h * R_earth * constants.g / (R_earth + h)
+    return z
+
+
+def geometric_height_from_geopotential_height(gh, R_earth=constants.R_earth):
+    r"""Compute the geometric height from geopotential height.
+
+    Parameters
+    ----------
+    gh : ndarray
+        Geopotential height (m)
+    R_earth : float, optional
+        Average radius of the Earth (m)
+
+    Returns
+    -------
+    ndarray
+        Geometric height (m)
+
+
+    The computation is based on the following formula:
+
+    .. math::
+
+        h = \frac{R_{earth}\; gh}{R_{earth} - gh}
+
+    where
+
+        * :math:`R_{earth}` is the average radius of the Earth (m)
+    """
+    h = R_earth * gh / (R_earth - gh)
+    return h
+
+
+def geometric_height_from_geopotential(z, R_earth=constants.R_earth):
+    r"""Compute the geometric height from geopotential.
+
+    Parameters
+    ----------
+    z : ndarray
+        Geopotential (m2/s2)
+    R_earth : float, optional
+        Average radius of the Earth (m)
+
+    Returns
+    -------
+    ndarray
+        Geometric height (m)
+
+
+    The computation is based on the following formula:
+
+    .. math::
+
+        h = \frac{R_{earth} \frac{z}{g}}{R_{earth} - \frac{z}{g}}
+
+    where
+
+        * :math:`R_{earth}` is the average radius of the Earth (m)
+        * :math:`g` is the gravitational acceleration on the surface of the Earth (m/s2)
+    """
+    z = z / constants.g
+    h = R_earth * z / (R_earth - z)
+    return h

--- a/src/earthkit/meteo/vertical/vertical.py
+++ b/src/earthkit/meteo/vertical/vertical.py
@@ -20,3 +20,23 @@ def relative_geopotential_thickness(*arg, **kwargs):
 
 def pressure_at_height_level(*args, **kwargs):
     return array.pressure_at_height_level(*args, **kwargs)
+
+
+def geopotential_height_from_geopotential(*args, **kwargs):
+    return array.geopotential_height_from_geopotential(*args, **kwargs)
+
+
+def geopotential_height_from_geometric_height(*args, **kwargs):
+    return array.geopotential_height_from_geometric_height(*args, **kwargs)
+
+
+def geopotential_from_geometric_height(*args, **kwargs):
+    return array.geopotential_from_geometric_height(*args, **kwargs)
+
+
+def geometric_height_from_geopotential_height(*args, **kwargs):
+    return array.geometric_height_from_geopotential_height(*args, **kwargs)
+
+
+def geometric_height_from_geopotential(*args, **kwargs):
+    return array.geometric_height_from_geopotential(*args, **kwargs)

--- a/tests/vertical/test_vertical.py
+++ b/tests/vertical/test_vertical.py
@@ -7,5 +7,98 @@
 # nor does it submit to any jurisdiction.
 #
 
+import numpy as np
+import pytest
 
-# TODO: add tests
+from earthkit.meteo import vertical
+
+
+@pytest.mark.parametrize(
+    "z,expected_value",
+    [(0, 0), (1000, 101.97162129779284), ([1000, 10000], [101.9716212978, 1019.7162129779])],
+)
+def test_geopotential_height_from_geopotential(z, expected_value):
+    if isinstance(z, list):
+        z = np.asarray(z)
+
+    r = vertical.geopotential_height_from_geopotential(z)
+
+    r = np.asarray(r)
+    expected_value = np.asarray(expected_value)
+    assert np.allclose(r, expected_value)
+
+
+@pytest.mark.parametrize(
+    "h,expected_value",
+    [
+        (0, 0),
+        (5102.664476187331, 50000),
+        ([1019.8794448450, 5102.6644761873, 7146.0195417809], [10000, 50000, 70000]),
+    ],
+)
+def test_geopotential_from_geometric_height(h, expected_value):
+    if isinstance(h, list):
+        h = np.asarray(h)
+
+    r = vertical.geopotential_from_geometric_height(h)
+
+    r = np.asarray(r)
+    expected_value = np.asarray(expected_value)
+    assert np.allclose(r, expected_value)
+
+
+@pytest.mark.parametrize(
+    "h,expected_value",
+    [
+        (0, 0),
+        (5003.9269715243, 5000),
+        ([1000.1569802279, 5003.9269715243, 7007.6992829768], [1000, 5000, 7000]),
+    ],
+)
+def test_geopotential_height_from_geometric_height(h, expected_value):
+    if isinstance(h, list):
+        h = np.asarray(h)
+
+    r = vertical.geopotential_height_from_geometric_height(h)
+
+    r = np.asarray(r)
+    expected_value = np.asarray(expected_value)
+    assert np.allclose(r, expected_value)
+
+
+@pytest.mark.parametrize(
+    "z,expected_value",
+    [
+        (0, 0),
+        (50000, 5102.664476187331),
+        ([10000, 50000, 70000], [1019.8794448450, 5102.6644761873, 7146.0195417809]),
+    ],
+)
+def test_geometric_height_from_geopotential(z, expected_value):
+    if isinstance(z, list):
+        z = np.asarray(z)
+
+    r = vertical.geometric_height_from_geopotential(z)
+
+    r = np.asarray(r)
+    expected_value = np.asarray(expected_value)
+    assert np.allclose(r, expected_value)
+
+
+@pytest.mark.parametrize(
+    "zh,expected_value",
+    [
+        (0, 0),
+        (5000, 5003.9269715243),
+        ([1000, 5000, 7000], [1000.1569802279, 5003.9269715243, 7007.6992829768]),
+    ],
+)
+def test_geometric_height_from_geopotential_height(zh, expected_value):
+    if isinstance(zh, list):
+        zh = np.asarray(zh)
+
+    r = vertical.geometric_height_from_geopotential_height(zh)
+
+    r = np.asarray(r)
+    expected_value = np.asarray(expected_value)
+    assert np.allclose(r, expected_value)


### PR DESCRIPTION
This PR adds the following methods to the `vertical` module:

- geopotential_height_from_geopotential(z)
- geopotential_height_from_geometric_height(h, R_earth=constants.R_earth)
- geopotential_from_geometric_height(h, R_earth=constants.R_earth)
- geometric_height_from_geopotential_height(gh, R_earth=constants.R_earth)
- geometric_height_from_geopotential(z, R_earth=constants.R_earth)