### PR TITLE
handle timezone aware datetimes in solar.py

### DIFF
--- a/src/earthkit/meteo/solar/array/solar.py
+++ b/src/earthkit/meteo/solar/array/solar.py
@@ -21,10 +21,10 @@ WARNING: This code is incomplete and not tested. DO NOT USE.
 
 def julian_day(date):
     if date.tzinfo is not None and date.tzinfo.utcoffset(date) is not None:
-            day_start = datetime.datetime(date.year, date.month, date.day, tzinfo=date.tzinfo)
+            year_start = datetime.datetime(date.year, 1, 1, tzinfo=date.tzinfo)
     else:
-            day_start = datetime.datetime(date.year, date.month, date.day)
-    delta = date - day_start
+            year_start = datetime.datetime(date.year, 1, 1)
+    delta = date - year_start
     return delta.days + delta.seconds / 86400.0
 
 

--- a/src/earthkit/meteo/solar/array/solar.py
+++ b/src/earthkit/meteo/solar/array/solar.py
@@ -20,7 +20,11 @@ WARNING: This code is incomplete and not tested. DO NOT USE.
 
 
 def julian_day(date):
-    delta = date - datetime.datetime(date.year, 1, 1)
+    if date.tzinfo is not None and date.tzinfo.utcoffset(date) is not None:
+            day_start = datetime.datetime(date.year, date.month, date.day, tzinfo=date.tzinfo)
+    else:
+            day_start = datetime.datetime(date.year, date.month, date.day)
+    delta = date - day_start
     return delta.days + delta.seconds / 86400.0
 
 

--- a/src/earthkit/meteo/solar/array/solar.py
+++ b/src/earthkit/meteo/solar/array/solar.py
@@ -21,9 +21,9 @@ WARNING: This code is incomplete and not tested. DO NOT USE.
 
 def julian_day(date):
     if date.tzinfo is not None and date.tzinfo.utcoffset(date) is not None:
-            year_start = datetime.datetime(date.year, 1, 1, tzinfo=date.tzinfo)
+        year_start = datetime.datetime(date.year, 1, 1, tzinfo=date.tzinfo)
     else:
-            year_start = datetime.datetime(date.year, 1, 1)
+        year_start = datetime.datetime(date.year, 1, 1)
     delta = date - year_start
     return delta.days + delta.seconds / 86400.0
 


### PR DESCRIPTION
I ran into the issue when running AIFS from MARS data - this takes care of the error.