### PR TITLE
implement nan_policy for crps

### DIFF
--- a/src/earthkit/meteo/score/array/crps.py
+++ b/src/earthkit/meteo/score/array/crps.py
@@ -19,6 +19,9 @@ def crps(x, y, nan_policy="propagate"):
         Ensemble forecast
     y: array-like (n_points)
         Observation/analysis
+    nan_policy: str
+        Determines how to handle nans.
+        Options are 'raise', 'propagate', or 'omit'.
 
     Returns
     -------
@@ -28,6 +31,9 @@ def crps(x, y, nan_policy="propagate"):
 
     The method is described in [Hersbach2000]_.
     """
+    if nan_policy not in ["raise", "propagate", "omit"]:
+        raise ValueError("Invalid argument: nan_policy must be 'raise', 'propagate', or 'omit'.")
+
     xp = array_namespace(x, y)
     x = xp.asarray(x)
     y = xp.asarray(y)

--- a/src/earthkit/meteo/score/array/crps.py
+++ b/src/earthkit/meteo/score/array/crps.py
@@ -10,7 +10,7 @@
 from earthkit.utils.array import array_namespace
 
 
-def crps(x, y, nan_policy='propagate'):
+def crps(x, y, nan_policy="propagate"):
     """Compute Continuous Ranked Probability Score (CRPS).
 
     Parameters
@@ -37,9 +37,9 @@ def crps(x, y, nan_policy='propagate'):
 
     isnan_mask = xp.any(xp.isnan(x), axis=0) | xp.isnan(y)
 
-    if nan_policy=='raise' and xp.any(isnan_mask):
+    if nan_policy == "raise" and xp.any(isnan_mask):
         raise ValueError(f"Missing values present in input and nan_policy={nan_policy}")
-    elif nan_policy=='omit':
+    elif nan_policy == "omit":
         x = x[..., ~isnan_mask]
         y = y[~isnan_mask]
 
@@ -69,7 +69,7 @@ def crps(x, y, nan_policy='propagate'):
     p_exp = xp.reshape(xp.arange(n_ens + 1) / float(n_ens), (n_ens + 1, *([1] * y.ndim)))
     crps = xp.sum(alpha * (p_exp**2) + beta * ((1 - p_exp) ** 2), axis=0)
 
-    if nan_policy=='propagate':
+    if nan_policy == "propagate":
         crps[isnan_mask] = xp.nan
 
     return crps


### PR DESCRIPTION
Close #43 

Implements a `nan_policy` for the CRPS function mimicing scipy's https://docs.scipy.org/doc/scipy/dev/api-dev/nan_policy.html.

Some caveats
- For the propagate case, this does some unnecessary computations for the values we later mask into nans
- For omit, I implemented as:
```
arr1 = np.ones((10,5)) # shape 2,5
arr2 = np.full(5, 2) # shape 5,
arr1[0][0]=np.nan
score.crps(arr1, arr2, 'omit')
>> array([1., 1., 1., 1.])
```
i.e. if any of the ensemble members are missing, we treat that slice as missing. We could also have thought about trying to compute with just the 9 valid ensemble members for this case, but that may be more confusing