### PR TITLE
replace arccos with acos as per array api spec

### DIFF
--- a/src/earthkit/meteo/extreme/array/efi.py
+++ b/src/earthkit/meteo/extreme/array/efi.py
@@ -54,7 +54,7 @@ def efi(clim, ens, eps=-0.1):
     dp = 1 / (nclim - 1)
     dFdp = xp.diff(frac, axis=0) / dp
 
-    acosdiff = xp.diff(xp.arccos(xp.sqrt(p)))
+    acosdiff = xp.diff(xp.acos(xp.sqrt(p)))
     proddiff = xp.diff(xp.sqrt(p * (1.0 - p)))
 
     acoef = (1.0 - 2.0 * p[:-1]) * acosdiff + proddiff


### PR DESCRIPTION
### Description
arccos isn't part of the array API spec, so we should be using acos: https://data-apis.org/array-api/2024.12/API_specification/generated/array_api.acos.html. Doesn't matter for torch, numpy, cupy since they implement both, but for example tf.arccos doesn't exist, only tf.acos.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 