### PR TITLE
Add KGE and KGE' scores for hydrological verification

### DIFF
--- a/docs/references.rst
+++ b/docs/references.rst
@@ -50,6 +50,10 @@ IFS Documentation CY47R3 - Part IV Physical processes, (2021). URL: https://www.
 
 IFS Documentation CY47R3 - Part III: Dynamics and numerical procedures, (2021). doi: `10.21957/b18qsx663 <http://dx.doi.org/10.21957/b18qsx663>`_
 
+.. [Kling2012]
+
+Kling, H., Fuchs, M., & Paulin, M. (2012). Runoff conditions in the upper Danube basin under an ensemble of climate change scenarios. Journal of hydrology, 424, 264-277. doi: `10.1016/j.jhydrol.2012.01.011 <https://doi.org/10.1016/j.jhydrol.2012.01.011>`_
+
 .. [Stipanuk1973]
 
 Stipanuk, G. S., (1973). Algorithms for Generating a Skew-T, Log P Diagram and Computing Selected Meteorological Quantities. Atmospheric Sciences Laboratory, U.S. Army Electronics Command. White Sands Missile Range, New Mexico 88002.

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -31,6 +31,10 @@ along Pseudoadiabats. Mon. Wea. Rev., 136, 2764-2785, doi: `10.1175/2007MWR2224.
 Gaussian quadrature.  URL: https://en.wikipedia.org/wiki/Gaussian_quadrature
 
 
+.. [Gupta2009]
+Gupta, H. V., Kling, H., Yilmaz, K. K., & Martinez, G. F. (2009). Decomposition of the mean squared error and NSE performance criteria: Implications for improving hydrological modelling. Journal of hydrology, 377(1-2), 80-91. doi: `10.1016/j.jhydrol.2009.08.003 <https://doi.org/10.1016/j.jhydrol.2009.08.003>`_
+
+
 .. [Hersbach2000]
 
 Hersbach, H., (2000). Decomposition of the Continuous Ranked Probability Score for Ensemble Prediction Systems. Weather and Forecasting 15: 559-570.

--- a/src/earthkit/meteo/score/__init__.py
+++ b/src/earthkit/meteo/score/__init__.py
@@ -17,3 +17,4 @@ planned to work with objects like *earthkit.data FieldLists* or *xarray DataSets
 
 from .correlation import *  # noqa
 from .crps import *  # noqa
+from .kge import *  # noqa

--- a/src/earthkit/meteo/score/array/kge.py
+++ b/src/earthkit/meteo/score/array/kge.py
@@ -1,0 +1,74 @@
+# (C) Copyright 2025 ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+#
+
+from earthkit.utils.array import array_namespace
+
+from .correlation import pearson
+
+
+def kge_prime(x, y, nan_policy="propagate", return_components=False):
+    """Compute Modified Kling–Gupta efficiency (KGE').
+
+    Parameters
+    ----------
+    x: array-like (n_points, n_samples)
+        Simulations for n_points points with n_samples samples each
+    y: array-like (n_points, n_samples)
+        Observations/ references for n_points points with n_samples samples each
+    nan_policy: str
+        Determines how to handle nans.
+        Options are 'raise', 'propagate', or 'omit'.
+    return_components: bool
+        If True, return kge, rho, beta, gamma as a stack of arrays with shape (4, n_points)
+        If False (default), return only kge with shape (n_points,)
+    Returns
+    -------
+    array-like (n_points,) or (4, n_points)
+        KGE' values or KGE' values and components (r, beta, gamma)
+        If return_components is True, the returned array has shape (4, n_points)
+        If nan_policy is 'omit', n_points is the number of points without nans
+
+
+    The method is described in [Kling2012]_.
+    """
+    if nan_policy not in {"raise", "propagate", "omit"}:
+        raise ValueError("Invalid argument: nan_policy must be 'raise', 'propagate', or 'omit'.")
+
+    xp = array_namespace(x, y)
+    x = xp.asarray(x)
+    y = xp.asarray(y)
+
+    if x.shape != y.shape:
+        raise ValueError(f"Input arrays must have the same shape, got {x.shape} and {y.shape}")
+
+    isnan_mask = xp.any(xp.isnan(x), axis=1) | xp.any(xp.isnan(y), axis=1)
+
+    if nan_policy == "raise" and xp.any(isnan_mask):
+        raise ValueError(f"Missing values present in input and nan_policy={nan_policy}")
+    elif nan_policy == "omit":
+        x = x[~isnan_mask, ...]
+        y = y[~isnan_mask, ...]
+
+    rho = pearson(x, y, axis=1)
+    beta = xp.mean(x, axis=1) / xp.mean(y, axis=1)
+    gamma = (xp.std(x, axis=1) / xp.mean(x, axis=1)) / (xp.std(y, axis=1) / xp.mean(y, axis=1))
+
+    kge = 1 - xp.sqrt((rho - 1) ** 2 + (beta - 1) ** 2 + (gamma - 1) ** 2)
+
+    if nan_policy == "propagate":
+        kge = xp.where(isnan_mask, xp.nan, kge)
+        rho = xp.where(isnan_mask, xp.nan, rho)
+        beta = xp.where(isnan_mask, xp.nan, beta)
+        gamma = xp.where(isnan_mask, xp.nan, gamma)
+
+    if return_components:
+        components = xp.stack((kge, rho, beta, gamma))
+        return components
+    else:
+        return kge

--- a/src/earthkit/meteo/score/array/kge.py
+++ b/src/earthkit/meteo/score/array/kge.py
@@ -12,8 +12,11 @@ from earthkit.utils.array import array_namespace
 from .correlation import pearson
 
 
-def kge_prime(x, y, nan_policy="propagate", return_components=False):
-    """Compute Modified Kling–Gupta efficiency (KGE').
+def kge(x, y, nan_policy="propagate", return_components=False):
+    """Compute Kling-Gupta efficiency (KGE).
+
+    This is an implementation of the original Kling-Gupta efficiency (KGE) metric
+    as described in [Gupta2009]_.
 
     Parameters
     ----------
@@ -25,17 +28,76 @@ def kge_prime(x, y, nan_policy="propagate", return_components=False):
         Determines how to handle nans.
         Options are 'raise', 'propagate', or 'omit'.
     return_components: bool
-        If True, return kge, rho, beta, gamma as a stack of arrays with shape (4, n_points)
-        If False (default), return only kge with shape (n_points,)
+        If True, return KGE, rho, alpha, beta as a stack of arrays with shape (4, n_points)
+        If False (default), return only KGE with shape (n_points,)
     Returns
     -------
     array-like (n_points,) or (4, n_points)
-        KGE' values or KGE' values and components (r, beta, gamma)
+        KGE values or KGE values and components (rho, alpha, beta)
         If return_components is True, the returned array has shape (4, n_points)
         If nan_policy is 'omit', n_points is the number of points without nans
+    """
+    if nan_policy not in {"raise", "propagate", "omit"}:
+        raise ValueError("Invalid argument: nan_policy must be 'raise', 'propagate', or 'omit'.")
+
+    xp = array_namespace(x, y)
+    x = xp.asarray(x)
+    y = xp.asarray(y)
+
+    if x.shape != y.shape:
+        raise ValueError(f"Input arrays must have the same shape, got {x.shape} and {y.shape}")
+
+    isnan_mask = xp.any(xp.isnan(x), axis=1) | xp.any(xp.isnan(y), axis=1)
+
+    if nan_policy == "raise" and xp.any(isnan_mask):
+        raise ValueError(f"Missing values present in input and nan_policy={nan_policy}")
+    elif nan_policy == "omit":
+        x = x[~isnan_mask, ...]
+        y = y[~isnan_mask, ...]
+
+    rho = pearson(x, y, axis=1)
+    alpha = xp.std(x, axis=1) / xp.std(y, axis=1)
+    beta = xp.mean(x, axis=1) / xp.mean(y, axis=1)
+
+    kge = 1 - xp.sqrt((rho - 1) ** 2 + (alpha - 1) ** 2 + (beta - 1) ** 2)
+
+    if nan_policy == "propagate":
+        kge = xp.where(isnan_mask, xp.nan, kge)
+        rho = xp.where(isnan_mask, xp.nan, rho)
+        alpha = xp.where(isnan_mask, xp.nan, alpha)
+        beta = xp.where(isnan_mask, xp.nan, beta)
+
+    if return_components:
+        components = xp.stack((kge, rho, alpha, beta))
+        return components
+    else:
+        return kge
 
 
-    The method is described in [Kling2012]_.
+def kge_prime(x, y, nan_policy="propagate", return_components=False):
+    """Compute Modified Kling-Gupta efficiency (KGE').
+
+    This is an implementation of the modified Kling-Gupta efficiency (KGE') metric
+    as described in [Kling2012]_.
+
+    Parameters
+    ----------
+    x: array-like (n_points, n_samples)
+        Simulations for n_points points with n_samples samples each
+    y: array-like (n_points, n_samples)
+        Observations/ references for n_points points with n_samples samples each
+    nan_policy: str
+        Determines how to handle nans.
+        Options are 'raise', 'propagate', or 'omit'.
+    return_components: bool
+        If True, return KGE', rho, beta, gamma as a stack of arrays with shape (4, n_points)
+        If False (default), return only KGE' with shape (n_points,)
+    Returns
+    -------
+    array-like (n_points,) or (4, n_points)
+        KGE' values or KGE' values and components (rho, beta, gamma)
+        If return_components is True, the returned array has shape (4, n_points)
+        If nan_policy is 'omit', n_points is the number of points without nans
     """
     if nan_policy not in {"raise", "propagate", "omit"}:
         raise ValueError("Invalid argument: nan_policy must be 'raise', 'propagate', or 'omit'.")

--- a/src/earthkit/meteo/score/kge.py
+++ b/src/earthkit/meteo/score/kge.py
@@ -10,5 +10,9 @@
 from . import array
 
 
+def kge(*args, **kwargs):
+    return array.kge(*args, **kwargs)
+
+
 def kge_prime(*args, **kwargs):
     return array.kge_prime(*args, **kwargs)

--- a/src/earthkit/meteo/score/kge.py
+++ b/src/earthkit/meteo/score/kge.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2021 ECMWF.
+# (C) Copyright 2025 ECMWF.
 #
 # This software is licensed under the terms of the Apache Licence Version 2.0
 # which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
@@ -7,10 +7,8 @@
 # nor does it submit to any jurisdiction.
 #
 
-"""
-Verification functions operating on numpy arrays.
-"""
+from . import array
 
-from .correlation import *  # noqa
-from .crps import *  # noqa
-from .kge import *  # noqa
+
+def kge_prime(*args, **kwargs):
+    return array.kge_prime(*args, **kwargs)

--- a/tests/score/_kge.py
+++ b/tests/score/_kge.py
@@ -49,15 +49,15 @@ v_ref_kge_prime_components = [
         -0.7165881091,
         0.8050195736,
         # Edge-cases: simulation
-        np.nan,  # zero variance
-        -np.inf,  # zero mean
-        np.nan,  # inf
-        np.nan,  # -inf
+        np.nan,
+        -np.inf,
+        np.nan,
+        np.nan,
         # Edge-cases: observation
-        np.nan,  # zero variance
-        -np.inf,  # zero mean
-        np.nan,  # inf
-        np.nan,  # -inf
+        np.nan,
+        -np.inf,
+        np.nan,
+        np.nan,
     ],
     # rho
     [
@@ -68,15 +68,15 @@ v_ref_kge_prime_components = [
         -0.4622436417,
         0.9987024321,
         # Edge-cases: simulation
-        np.nan,  # zero variance
-        1.0,  # zero mean
-        np.nan,  # inf
-        np.nan,  # -inf
+        np.nan,
+        1.0,
+        np.nan,
+        np.nan,
         # Edge-cases: observation
-        np.nan,  # zero variance
-        1.0,  # zero mean
-        np.nan,  # inf
-        np.nan,  # -inf
+        np.nan,
+        1.0,
+        np.nan,
+        np.nan,
     ],
     # beta
     [
@@ -87,15 +87,15 @@ v_ref_kge_prime_components = [
         1.6197183099,
         0.8818181818,
         # Edge-cases: simulation
-        0.45454545,  # zero variance
-        0.0,  # zero mean
-        np.inf,  # inf
-        -np.inf,  # -inf
+        0.45454545,
+        0.0,
+        np.inf,
+        -np.inf,
         # Edge-cases: observation
-        2.2,  # zero variance
-        np.inf,  # zero mean
-        0,  # inf
-        0,  # -inf
+        2.2,
+        np.inf,
+        0,
+        0,
     ],
     # gamma
     [
@@ -106,14 +106,94 @@ v_ref_kge_prime_components = [
         0.3484883080,
         0.8449234356,
         # Edge-cases: simulation
-        0.0,  # zero variance
-        np.inf,  # zero mean
-        np.nan,  # inf
-        np.nan,  # -inf
+        0.0,
+        np.inf,
+        np.nan,
+        np.nan,
         # Edge-cases: observation
-        np.inf,  # zero variance
-        0.0,  # zero mean
-        np.nan,  # inf
-        np.nan,  # -inf
+        np.inf,
+        0.0,
+        np.nan,
+        np.nan,
+    ],
+]
+
+
+v_ref_kge_components = [
+    # KGE
+    [
+        1.0,
+        -0.46476861,
+        0.06826592,
+        -0.40116796,
+        -0.64678734,
+        0.71900442,
+        # Edge-cases: simulation
+        np.nan,
+        -0.00412373,
+        np.nan,
+        np.nan,
+        # Edge-cases: observation
+        np.nan,
+        -np.inf,
+        np.nan,
+        np.nan,
+    ],
+    # rho
+    [
+        1.0000000000,
+        0.5934940644,
+        0.3747797925,
+        -0.1795676428,
+        -0.4622436417,
+        0.9987024321,
+        # Edge-cases: simulation
+        np.nan,
+        1.0,
+        np.nan,
+        np.nan,
+        # Edge-cases: observation
+        np.nan,
+        1.0,
+        np.nan,
+        np.nan,
+    ],
+    # alpha
+    [
+        1.0,
+        0.18113070786957505,
+        1.6906124944445566,
+        0.5347125362695476,
+        0.5644528931691898,
+        0.7450688477363122,
+        # Edge-cases: simulation
+        0.0,
+        0.9090909090909091,
+        np.nan,
+        np.nan,
+        # Edge-cases: observation
+        np.inf,
+        1.0999999999999999,
+        np.nan,
+        np.nan,
+    ],
+    # beta
+    [
+        1.0000000000,
+        -0.1444444444,
+        0.9831932773,
+        0.4038461538,
+        1.6197183099,
+        0.8818181818,
+        # Edge-cases: simulation
+        0.45454545,
+        0.0,
+        np.inf,
+        -np.inf,
+        # Edge-cases: observation
+        2.2,
+        np.inf,
+        0,
+        0,
     ],
 ]

--- a/tests/score/_kge.py
+++ b/tests/score/_kge.py
@@ -39,85 +39,6 @@ obs = [
     [1.0, 2, -np.inf],  # -Inf
 ]
 
-v_ref_kge_prime_components = [
-    # KGE'
-    [
-        1.0000000000,
-        -1.5603582218,
-        0.0466479764,
-        -0.3608040612,
-        -0.7165881091,
-        0.8050195736,
-        # Edge-cases: simulation
-        np.nan,
-        -np.inf,
-        np.nan,
-        np.nan,
-        # Edge-cases: observation
-        np.nan,
-        -np.inf,
-        np.nan,
-        np.nan,
-    ],
-    # rho
-    [
-        1.0000000000,
-        0.5934940644,
-        0.3747797925,
-        -0.1795676428,
-        -0.4622436417,
-        0.9987024321,
-        # Edge-cases: simulation
-        np.nan,
-        1.0,
-        np.nan,
-        np.nan,
-        # Edge-cases: observation
-        np.nan,
-        1.0,
-        np.nan,
-        np.nan,
-    ],
-    # beta
-    [
-        1.0000000000,
-        -0.1444444444,
-        0.9831932773,
-        0.4038461538,
-        1.6197183099,
-        0.8818181818,
-        # Edge-cases: simulation
-        0.45454545,
-        0.0,
-        np.inf,
-        -np.inf,
-        # Edge-cases: observation
-        2.2,
-        np.inf,
-        0,
-        0,
-    ],
-    # gamma
-    [
-        1.0000000000,
-        -1.2539818237,
-        1.7195118533,
-        1.3240500898,
-        0.3484883080,
-        0.8449234356,
-        # Edge-cases: simulation
-        0.0,
-        np.inf,
-        np.nan,
-        np.nan,
-        # Edge-cases: observation
-        np.inf,
-        0.0,
-        np.nan,
-        np.nan,
-    ],
-]
-
 
 v_ref_kge_components = [
     # KGE
@@ -195,5 +116,84 @@ v_ref_kge_components = [
         np.inf,
         0,
         0,
+    ],
+]
+
+v_ref_kge_prime_components = [
+    # KGE'
+    [
+        1.0000000000,
+        -1.5603582218,
+        0.0466479764,
+        -0.3608040612,
+        -0.7165881091,
+        0.8050195736,
+        # Edge-cases: simulation
+        np.nan,
+        -np.inf,
+        np.nan,
+        np.nan,
+        # Edge-cases: observation
+        np.nan,
+        -np.inf,
+        np.nan,
+        np.nan,
+    ],
+    # rho
+    [
+        1.0000000000,
+        0.5934940644,
+        0.3747797925,
+        -0.1795676428,
+        -0.4622436417,
+        0.9987024321,
+        # Edge-cases: simulation
+        np.nan,
+        1.0,
+        np.nan,
+        np.nan,
+        # Edge-cases: observation
+        np.nan,
+        1.0,
+        np.nan,
+        np.nan,
+    ],
+    # beta
+    [
+        1.0000000000,
+        -0.1444444444,
+        0.9831932773,
+        0.4038461538,
+        1.6197183099,
+        0.8818181818,
+        # Edge-cases: simulation
+        0.45454545,
+        0.0,
+        np.inf,
+        -np.inf,
+        # Edge-cases: observation
+        2.2,
+        np.inf,
+        0,
+        0,
+    ],
+    # gamma
+    [
+        1.0000000000,
+        -1.2539818237,
+        1.7195118533,
+        1.3240500898,
+        0.3484883080,
+        0.8449234356,
+        # Edge-cases: simulation
+        0.0,
+        np.inf,
+        np.nan,
+        np.nan,
+        # Edge-cases: observation
+        np.inf,
+        0.0,
+        np.nan,
+        np.nan,
     ],
 ]

--- a/tests/score/_kge.py
+++ b/tests/score/_kge.py
@@ -1,0 +1,119 @@
+import numpy as np
+
+sim = [
+    # Normal cases
+    [0.0, 1.0, 2.0],
+    [0.05, 0.48, 0.77],
+    [0.06, 0.66, 0.45],
+    [0.21, 0.05, 0.16],
+    [0.61, 0.8, 0.89],
+    [0.53, 0.14, 0.3],
+    # Edge-cases: simulation
+    [1.0, 1.0, 1.0],  # zero variance
+    [-1.0, 0.0, 1.0],  # zero mean
+    [1.0, 2, np.inf],  # Inf
+    [1.0, 2, -np.inf],  # -Inf
+    # Edge-cases: observation
+    [1.1, 2.2, 3.3],
+    [1.1, 2.2, 3.3],
+    [1.1, 2.2, 3.3],
+    [1.1, 2.2, 3.3],
+]
+
+obs = [
+    [0.0, 1.0, 2.0],
+    [-5.0, -1.0, -3.0],
+    [0.39, 0.58, 0.22],
+    [0.44, 0.43, 0.17],
+    [0.52, 0.7, 0.2],
+    [0.65, 0.13, 0.32],
+    # Edge-cases: simulation
+    [1.1, 2.2, 3.3],
+    [1.1, 2.2, 3.3],
+    [1.1, 2.2, 3.3],
+    [1.1, 2.2, 3.3],
+    # Edge-cases: observation
+    [1.0, 1.0, 1.0],  # zero variance
+    [-1.0, 0.0, 1.0],  # zero mean
+    [1.0, 2, np.inf],  # Inf
+    [1.0, 2, -np.inf],  # -Inf
+]
+
+v_ref_kge_prime_components = [
+    # KGE'
+    [
+        1.0000000000,
+        -1.5603582218,
+        0.0466479764,
+        -0.3608040612,
+        -0.7165881091,
+        0.8050195736,
+        # Edge-cases: simulation
+        np.nan,  # zero variance
+        -np.inf,  # zero mean
+        np.nan,  # inf
+        np.nan,  # -inf
+        # Edge-cases: observation
+        np.nan,  # zero variance
+        -np.inf,  # zero mean
+        np.nan,  # inf
+        np.nan,  # -inf
+    ],
+    # rho
+    [
+        1.0000000000,
+        0.5934940644,
+        0.3747797925,
+        -0.1795676428,
+        -0.4622436417,
+        0.9987024321,
+        # Edge-cases: simulation
+        np.nan,  # zero variance
+        1.0,  # zero mean
+        np.nan,  # inf
+        np.nan,  # -inf
+        # Edge-cases: observation
+        np.nan,  # zero variance
+        1.0,  # zero mean
+        np.nan,  # inf
+        np.nan,  # -inf
+    ],
+    # beta
+    [
+        1.0000000000,
+        -0.1444444444,
+        0.9831932773,
+        0.4038461538,
+        1.6197183099,
+        0.8818181818,
+        # Edge-cases: simulation
+        0.45454545,  # zero variance
+        0.0,  # zero mean
+        np.inf,  # inf
+        -np.inf,  # -inf
+        # Edge-cases: observation
+        2.2,  # zero variance
+        np.inf,  # zero mean
+        0,  # inf
+        0,  # -inf
+    ],
+    # gamma
+    [
+        1.0000000000,
+        -1.2539818237,
+        1.7195118533,
+        1.3240500898,
+        0.3484883080,
+        0.8449234356,
+        # Edge-cases: simulation
+        0.0,  # zero variance
+        np.inf,  # zero mean
+        np.nan,  # inf
+        np.nan,  # -inf
+        # Edge-cases: observation
+        np.inf,  # zero variance
+        0.0,  # zero mean
+        np.nan,  # inf
+        np.nan,  # -inf
+    ],
+]


### PR DESCRIPTION
### Description

This proposes the addition of two new scores `kge` and `kge_prime` to `earthkit.meteo.score`. I’ll be using `kge_prime` for another project and thought they’d be a nice addition to earthkit-meteo.

The two implementations are based on the respective papers in which they were introduced:
- KGE: https://doi.org/10.1016/j.jhydrol.2009.08.003
- KGE': https://doi.org/10.1016/j.jhydrol.2012.01.011

The formula for the original KGE can also be found [on wikipedia](https://en.wikipedia.org/wiki/Kling%E2%80%93Gupta_efficiency) and a reference implementation for KGE' can be found [here](https://github.com/ecmwf/hat/blob/6ad904246fa75c3dbf453459961fabf1c2dccb3a/hat/compute_hydrostats/stats.py#L61C1-L68C67). 

I included a few test cases for both that document behavior in edge cases (e.g., zero mean or zero variance in one of the input arrays) that might produce unexpected results.

A few notes on the implementation:
- Small shared base class to centralise input checks and NaN handling (raise/propagate/omit).
- Simulation and observation inputs must be 2D (n_points, n_samples). Passing 1D arrays (n_samples,) is not supported and users must e.g. use `x[None, :]` and `y[None, :]`.
- All KGE components can be returned by setting `return_components=True`.
- Array API friendly; tested locally with NumPy and PyTorch.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 