### PR TITLE
chore: use atan2 instead of arctan2 as per array-api-spec

### DIFF
--- a/src/earthkit/meteo/wind/array/wind.py
+++ b/src/earthkit/meteo/wind/array/wind.py
@@ -40,7 +40,7 @@ def _direction_meteo(u, v):
     v = xp.asarray(v)
 
     minus_pi2 = -xp.pi / 2.0
-    d = xp.arctan2(v, u)
+    d = xp.atan2(v, u)
     d = xp.asarray(d)
     m = d <= minus_pi2
     d[m] = (minus_pi2 - d[m]) * constants.degree
@@ -53,7 +53,7 @@ def _direction_polar(u, v, to_positive):
     xp = array_namespace(u, v)
     u = xp.asarray(u)
     v = xp.asarray(v)
-    d = xp.arctan2(v, u) * constants.degree
+    d = xp.atan2(v, u) * constants.degree
     if to_positive:
         d = xp.asarray(d)
         m = d < 0


### PR DESCRIPTION
### Description
`xp.arctan2` is not part of the array-api-spec, switch to `xp.atan2`. Part of #61 

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 