### PR TITLE
chore: replace deg2rad with array-api-spec version

### DIFF
--- a/src/earthkit/meteo/solar/array/solar.py
+++ b/src/earthkit/meteo/solar/array/solar.py
@@ -12,6 +12,8 @@ import datetime
 import numpy as np
 from earthkit.utils.array import array_namespace
 
+from earthkit.meteo.constants import radian
+
 DAYS_PER_YEAR = 365.25
 
 
@@ -77,16 +79,14 @@ def cos_solar_zenith_angle(date, latitudes, longitudes):
     longitudes = xp.asarray(longitudes)
 
     # solar_declination_angle returns degrees
-    # TODO: deg2rad() is not part of the array API standard
-    declination = xp.deg2rad(declination)
-    latitudes = xp.deg2rad(latitudes)
+    declination = declination * radian
+    latitudes = latitudes * radian
 
     sindec_sinlat = xp.sin(declination) * xp.sin(latitudes)
     cosdec_coslat = xp.cos(declination) * xp.cos(latitudes)
 
     # solar hour angle [h.deg]
-    # TODO: deg2rad() is not part of the array API standard
-    solar_angle = xp.deg2rad((date.hour - 12) * 15 + longitudes + time_correction)
+    solar_angle = ((date.hour - 12) * 15 + longitudes + time_correction) * radian
     zenith_angle = sindec_sinlat + cosdec_coslat * xp.cos(solar_angle)
 
     # Clip negative values


### PR DESCRIPTION
### Description
`xp.deg2rad` is not part of the array-api-spec. Part of #61 

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 