### PR TITLE
extreme.cpf: make computation more resilient to 'reverse crossings'

### DIFF
--- a/tests/extreme/_cpf.py
+++ b/tests/extreme/_cpf.py
@@ -1,6 +1,7 @@
 import numpy as np
 
-cpf_val = np.array([0.0, 1.0, 0.21153846, 0.53846157, 0.7307692], dtype=np.float32)
+cpf_val = np.array([0.0, 1.0, 0.0, 0.53846157, 0.7307692], dtype=np.float32)
+cpf_val_fromzero = np.array([0.0, 1.0, 0.21153846, 0.53846157, 0.7307692], dtype=np.float32)
 cpf_ens = np.array(
     [
         [299.3667, 299.97998, 276.91553, 298.83936, 296.2339],
@@ -328,7 +329,7 @@ cpf_clim2 = np.array(
     dtype=np.float32,
 )
 
-cpf_val3 = np.array([0.97483208, 0.11538463, 1.0, 0.59615387, 1.0], dtype=np.float32)
+cpf_val3 = np.array([0.9809273481, 0.1153846383, 0.9897592068, 0.5961538553, 1.0], dtype=np.float32)
 cpf_ens3 = np.array(
     [
         [298.41162109, 297.77490234, 298.49560547, 284.96630859, 300.28857422],

--- a/tests/extreme/test_extreme.py
+++ b/tests/extreme/test_extreme.py
@@ -189,7 +189,8 @@ def test_cpf_highlevel(clim, ens, v_ref, array_backend):
     [
         (_cpf.cpf_clim, _cpf.cpf_ens, dict(sort_clim=True), _cpf.cpf_val),
         (_cpf.cpf_clim2, _cpf.cpf_ens2, dict(sort_clim=True, epsilon=0.5), _cpf.cpf_val2),  # eps
-        # (_cpf.cpf_clim3, _cpf.cpf_ens3, dict(sort_clim=True, symmetric=True), _cpf.cpf_val3),  # sym
+        (_cpf.cpf_clim3, _cpf.cpf_ens3, dict(sort_clim=True, symmetric=True), _cpf.cpf_val3),  # sym
+        (_cpf.cpf_clim, _cpf.cpf_ens, dict(sort_clim=True, from_zero=True), _cpf.cpf_val_fromzero),
     ],
 )
 def test_cpf_core(clim, ens, v_ref, kwargs, array_backend):


### PR DESCRIPTION
### Description

Introduces a `from_zero` parameter to `extreme.cpf`, default to False (previous behaviour corresponds to True), ignoring the lower half of the distribution. Also adds an extra check for "reverse crossings", i.e. when the forecast CDF starts above the climate distribution.


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 