### PR TITLE
Fix quantiles with method=sort

### DIFF
--- a/src/earthkit/meteo/stats/array/quantiles.py
+++ b/src/earthkit/meteo/stats/array/quantiles.py
@@ -65,7 +65,7 @@ def iter_quantiles(
     if method == "sort":
         arr = xp.asarray(arr)
         arr = xp.sort(arr, axis=axis)
-        missing = xp.any(xp.isnan(arr), axis=axis, keepdims=True)
+        missing = xp.any(xp.isnan(arr), axis=axis)
 
     for q in qs:
         if method == "numpy":

--- a/tests/stats/test_stats.py
+++ b/tests/stats/test_stats.py
@@ -157,10 +157,13 @@ def test_quantiles_core(xp, device, data, which, kwargs, v_ref, method):
 def test_quantiles_nans(xp, device, arr):
     arr = xp.asarray(arr, device=device)
     qs = xp.asarray([0.0, 0.25, 0.5, 0.75, 1.0], device=device)
-    r1 = [quantile for quantile in stats.iter_quantiles(arr, qs, method="sort")]
-    r2 = [quantile for quantile in stats.iter_quantiles(arr, qs, method="numpy")]
-    for i, (d1, d2) in enumerate(zip(r1, r2)):
-        assert xp.allclose(d1, d2, equal_nan=True), f"quantile={qs[i]}"
+    bulk = xp.asarray([quantile for quantile in stats.iter_quantiles(arr, qs, method="numpy_bulk")])
+    r1 = xp.asarray([quantile for quantile in stats.iter_quantiles(arr, qs, method="sort")])
+    assert bulk.shape == r1.shape
+    assert xp.allclose(bulk, r1, equal_nan=True)
+    r2 = xp.asarray([quantile for quantile in stats.iter_quantiles(arr, qs, method="numpy")])
+    assert bulk.shape == r2.shape
+    assert xp.allclose(bulk, r2, equal_nan=True)
 
 
 def test_GumbelDistribution():


### PR DESCRIPTION
### Description
Revert change to shape of array returned from `iter_quantiles` with `method=sort`. The output shape should be the same as that returned by other methods. Modified test to ensure shape of returns is as expected.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 