### PR TITLE
Add xarray support to the `solar` module

### DIFF
--- a/src/earthkit/meteo/solar/__init__.py
+++ b/src/earthkit/meteo/solar/__init__.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2021 ECMWF.
+# (C) Copyright 2026 ECMWF.
 #
 # This software is licensed under the terms of the Apache Licence Version 2.0
 # which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
@@ -17,3 +17,12 @@ planned to work with objects like *earthkit.data FieldLists* or *xarray DataSets
 """
 
 from .solar import *  # noqa
+
+__all__ = [
+    "julian_day",
+    "solar_declination_angle",
+    "cos_solar_zenith_angle",
+    "cos_solar_zenith_angle_integrated",
+    "incoming_solar_radiation",
+    "toa_incident_solar_radiation",
+]

--- a/src/earthkit/meteo/solar/array/solar.py
+++ b/src/earthkit/meteo/solar/array/solar.py
@@ -15,57 +15,97 @@ from earthkit.utils.array import array_namespace
 DAYS_PER_YEAR = 365.25
 
 
-def julian_day(date):
-    """Day of year as a fractional value.
+def _julian_day_scalar(d: datetime.datetime) -> float:
+    """Compute fractional day-of-year for a single datetime.
 
     Parameters
     ----------
-    date : array-like
-        Input date.
+    d : datetime.datetime
+        Input datetime.
 
     Returns
     -------
-    array-like
-        Number of days since January 1st of the same year, including
-        fractional day component based on the time of day.
-
-    Notes
-    -----
-    This is not the astronomical Julian Day Number. It is the day-of-year
-    (DOY) expressed as a floating-point value.
+    float
+        Day-of-year as a fractional value, where January 1st 00:00 is 0.0.
     """
-    if date.tzinfo is not None and date.tzinfo.utcoffset(date) is not None:
-        year_start = datetime.datetime(date.year, 1, 1, tzinfo=date.tzinfo)
+    if d.tzinfo is not None and d.tzinfo.utcoffset(d) is not None:
+        year_start = datetime.datetime(d.year, 1, 1, tzinfo=d.tzinfo)
     else:
-        year_start = datetime.datetime(date.year, 1, 1)
-    delta = date - year_start
+        year_start = datetime.datetime(d.year, 1, 1)
+    delta = d - year_start
     return delta.days + delta.seconds / 86400.0
 
 
-def solar_declination_angle(date):
-    """Compute solar declination and time correction.
+def julian_day(date) -> float:
+    """Compute fractional day-of-year.
 
     Parameters
     ----------
-    date : array-like
-        Input date.
+    date : datetime.datetime, numpy.datetime64, or numpy.ndarray
+        Input date(s). May be a scalar or array of numpy.datetime64 or
+        datetime.datetime objects.
 
     Returns
     -------
-    tuple of float
-        declination : float
-            Solar declination angle [degrees].
-        time_correction : float
-            Time correction factor [hour-degrees].
+    float or numpy.ndarray
+        Fractional day-of-year value(s), where January 1st 00:00 is 0.0.
+
+    Notes
+    -----
+    This function supports:
+
+    - Python ``datetime.datetime`` scalars
+    - ``numpy.datetime64`` scalars
+    - numpy arrays of dtype ``datetime64``
+
+    This enables compatibility with xarray, which internally represents
+    time coordinates using numpy.datetime64.
+    """
+    # numpy.datetime64 scalar
+    if isinstance(date, np.datetime64):
+        d_obj = date.astype("datetime64[us]").astype(object)
+        return _julian_day_scalar(d_obj)
+
+    # numpy datetime64 array
+    if isinstance(date, np.ndarray) and np.issubdtype(date.dtype, np.datetime64):
+        obj = date.astype("datetime64[us]").astype(object)
+        return np.vectorize(_julian_day_scalar, otypes=[float])(obj)
+
+    # python datetime.datetime
+    return _julian_day_scalar(date)
+
+
+def solar_declination_angle(date) -> tuple[float, float]:
+    """Compute solar declination angle and time correction.
+
+    Parameters
+    ----------
+    date : datetime.datetime, numpy.datetime64, or numpy.ndarray
+        Input date(s). May be scalar or array.
+
+    Returns
+    -------
+    tuple of float or numpy.ndarray
+        Tuple containing:
+
+        declination : float or numpy.ndarray
+            Solar declination angle in degrees.
+
+        time_correction : float or numpy.ndarray
+            Time correction factor in hour-degrees.
 
     Notes
     -----
     Uses a trigonometric approximation based on the fractional year angle.
+
+    This function supports numpy.datetime64 inputs, allowing use with xarray
+    and other numpy-based datetime containers.
+
+    Scalar inputs return floats, array inputs return numpy arrays.
     """
     angle = julian_day(date) / DAYS_PER_YEAR * np.pi * 2
 
-    # declination in [degrees]
-    declination = float(
+    declination = (
         0.396372
         - 22.91327 * np.cos(angle)
         + 4.025430 * np.sin(angle)
@@ -74,62 +114,68 @@ def solar_declination_angle(date):
         - 0.154527 * np.cos(3 * angle)
         + 0.084798 * np.sin(3 * angle)
     )
-    # time correction in [ h.degrees ]
-    time_correction = float(
+
+    time_correction = (
         0.004297
         + 0.107029 * np.cos(angle)
         - 1.837877 * np.sin(angle)
         - 0.837378 * np.cos(2 * angle)
         - 2.340475 * np.sin(2 * angle)
     )
+
+    if np.ndim(declination) == 0:
+        return float(declination), float(time_correction)
+
     return declination, time_correction
 
 
-def cos_solar_zenith_angle(date, latitudes, longitudes):
-    """Cosine of solar zenith angle.
+def cos_solar_zenith_angle(
+    date: datetime.datetime,
+    latitudes,
+    longitudes,
+):
+    """Compute cosine of the solar zenith angle.
 
     Parameters
     ----------
-    date: datetime.datetime
-        Date
-    latitudes: array-like
-        Latitude [degrees]
-    longitudes: array-like
-        Longitude [degrees]
+    date : datetime.datetime
+        Date and time of the observation.
+    latitudes : array-like
+        Latitude values in degrees.
+    longitudes : array-like
+        Longitude values in degrees.
 
     Returns
     -------
-    float array
-        Cosine of the solar zenith angle (all values, including negatives)
-        [Hogan_and_Hirahara2015]_. See also:
-        http://answers.google.com/answers/threadview/id/782886.html
+    array-like
+        Cosine of the solar zenith angle. Negative values are clipped to 0.
 
+    Notes
+    -----
+    Supports any array type compatible with the Python Array API standard,
+    including numpy, cupy, and torch tensors.
+
+    The result is clipped to ensure physically meaningful values.
     """
     xp = array_namespace(latitudes, longitudes)
     latitudes = xp.asarray(latitudes)
     longitudes = xp.asarray(longitudes)
     device = xp.device(latitudes)
 
-    # declination angle + time correction for solar angle
     declination, time_correction = solar_declination_angle(date)
 
     declination = xp.asarray(declination, device=device)
     time_correction = xp.asarray(time_correction, device=device)
 
-    # solar_declination_angle returns degrees
-    # TODO: deg2rad() is not part of the array API standard
     declination = xp.deg2rad(declination)
     latitudes = xp.deg2rad(latitudes)
 
     sindec_sinlat = xp.sin(declination) * xp.sin(latitudes)
     cosdec_coslat = xp.cos(declination) * xp.cos(latitudes)
 
-    # solar hour angle [h.deg]
-    # TODO: deg2rad() is not part of the array API standard
     solar_angle = xp.deg2rad((date.hour - 12) * 15 + longitudes + time_correction)
     zenith_angle = sindec_sinlat + cosdec_coslat * xp.cos(solar_angle)
 
-    # Clip negative values
     return xp.clip(zenith_angle, 0.0, None)
 
 

--- a/src/earthkit/meteo/solar/array/solar.py
+++ b/src/earthkit/meteo/solar/array/solar.py
@@ -20,7 +20,7 @@ def _julian_day_scalar(d: datetime.datetime) -> float:
 
     Parameters
     ----------
-    d : datetime.datetime
+    d: datetime.datetime
         Input datetime.
 
     Returns
@@ -41,7 +41,7 @@ def julian_day(date) -> float:
 
     Parameters
     ----------
-    date : datetime.datetime, numpy.datetime64, or numpy.ndarray
+    date: datetime.datetime, numpy.datetime64, or numpy.ndarray
         Input date(s). May be a scalar or array of numpy.datetime64 or
         datetime.datetime objects.
 
@@ -80,7 +80,7 @@ def solar_declination_angle(date) -> tuple[float, float]:
 
     Parameters
     ----------
-    date : datetime.datetime, numpy.datetime64, or numpy.ndarray
+    date: datetime.datetime, numpy.datetime64, or numpy.ndarray
         Input date(s). May be scalar or array.
 
     Returns
@@ -105,6 +105,7 @@ def solar_declination_angle(date) -> tuple[float, float]:
     """
     angle = julian_day(date) / DAYS_PER_YEAR * np.pi * 2
 
+    # declination in [degrees]
     declination = (
         0.396372
         - 22.91327 * np.cos(angle)
@@ -114,7 +115,7 @@ def solar_declination_angle(date) -> tuple[float, float]:
         - 0.154527 * np.cos(3 * angle)
         + 0.084798 * np.sin(3 * angle)
     )
-
+    # time correction in [ h.degrees ]
     time_correction = (
         0.004297
         + 0.107029 * np.cos(angle)
@@ -138,44 +139,46 @@ def cos_solar_zenith_angle(
 
     Parameters
     ----------
-    date : datetime.datetime
-        Date and time of the observation.
-    latitudes : array-like
+    date: datetime.datetime
+        Date.
+    latitudes: array-like
         Latitude values in degrees.
-    longitudes : array-like
+    longitudes: array-like
         Longitude values in degrees.
 
     Returns
     -------
     array-like
         Cosine of the solar zenith angle. Negative values are clipped to 0.
+        [Hogan_and_Hirahara2015]_. See also:
+        http://answers.google.com/answers/threadview/id/782886.html
 
-    Notes
-    -----
-    Supports any array type compatible with the Python Array API standard,
-    including numpy, cupy, and torch tensors.
-
-    The result is clipped to ensure physically meaningful values.
     """
     xp = array_namespace(latitudes, longitudes)
     latitudes = xp.asarray(latitudes)
     longitudes = xp.asarray(longitudes)
     device = xp.device(latitudes)
 
+    # declination angle + time correction for solar angle
     declination, time_correction = solar_declination_angle(date)
 
     declination = xp.asarray(declination, device=device)
     time_correction = xp.asarray(time_correction, device=device)
 
+    # solar_declination_angle returns degrees
+    # TODO: deg2rad() is not part of the array API standard
     declination = xp.deg2rad(declination)
     latitudes = xp.deg2rad(latitudes)
 
     sindec_sinlat = xp.sin(declination) * xp.sin(latitudes)
     cosdec_coslat = xp.cos(declination) * xp.cos(latitudes)
 
+    # solar hour angle [h.deg]
+    # TODO: deg2rad() is not part of the array API standard
     solar_angle = xp.deg2rad((date.hour - 12) * 15 + longitudes + time_correction)
     zenith_angle = sindec_sinlat + cosdec_coslat * xp.cos(solar_angle)
 
+    # Clip negative values
     return xp.clip(zenith_angle, 0.0, None)
 
 

--- a/src/earthkit/meteo/solar/array/solar.py
+++ b/src/earthkit/meteo/solar/array/solar.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2021 ECMWF.
+# (C) Copyright 2026 ECMWF.
 #
 # This software is licensed under the terms of the Apache Licence Version 2.0
 # which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
@@ -16,6 +16,24 @@ DAYS_PER_YEAR = 365.25
 
 
 def julian_day(date):
+    """Day of year as a fractional value.
+
+    Parameters
+    ----------
+    date : array-like
+        Input date.
+
+    Returns
+    -------
+    array-like
+        Number of days since January 1st of the same year, including
+        fractional day component based on the time of day.
+
+    Notes
+    -----
+    This is not the astronomical Julian Day Number. It is the day-of-year
+    (DOY) expressed as a floating-point value.
+    """
     if date.tzinfo is not None and date.tzinfo.utcoffset(date) is not None:
         year_start = datetime.datetime(date.year, 1, 1, tzinfo=date.tzinfo)
     else:
@@ -25,6 +43,25 @@ def julian_day(date):
 
 
 def solar_declination_angle(date):
+    """Compute solar declination and time correction.
+
+    Parameters
+    ----------
+    date : array-like
+        Input date.
+
+    Returns
+    -------
+    tuple of float
+        declination : float
+            Solar declination angle [degrees].
+        time_correction : float
+            Time correction factor [hour-degrees].
+
+    Notes
+    -----
+    Uses a trigonometric approximation based on the fractional year angle.
+    """
     angle = julian_day(date) / DAYS_PER_YEAR * np.pi * 2
 
     # declination in [degrees]

--- a/src/earthkit/meteo/solar/solar.py
+++ b/src/earthkit/meteo/solar/solar.py
@@ -26,14 +26,16 @@ if TYPE_CHECKING:
     import numpy as np
     import xarray  # type: ignore[import]
 
-# NOTE: this must exist at runtime too (don’t put it under TYPE_CHECKING)
 DateLike: TypeAlias = "datetime.datetime | np.datetime64"
 
 ArrayLike: TypeAlias = Any
 
 
 def _dispatch_if_xarray(func_name: str, *args: Any, **kwargs: Any) -> Any | None:
-    """Dispatch to the xarray implementation if any positional argument is xarray."""
+    # Solar functions often take `date` as a scalar and lat/lon as xarray objects.
+    # The default dispatch() only checks the first argument, so it would incorrectly
+    # select the array backend and drop xarray metadata. This ensures we use the
+    # xarray implementation whenever any argument is xarray.
     if any(_is_xarray(a) for a in args):
         module = import_module(__name__.rsplit(".", 1)[0] + ".xarray")
         return getattr(module, func_name)(*args, **kwargs)
@@ -63,10 +65,10 @@ def julian_day(date):
 
     - :py:meth:`earthkit.meteo.solar.xarray.julian_day` for xarray.DataArray
     - :py:meth:`earthkit.meteo.solar.array.julian_day` for scalar/array inputs
-      (including ``numpy.datetime64``)
 
     """
-    return dispatch(julian_day, date)
+    r = dispatch(julian_day, date)
+    return r if r is not None else array.julian_day(date)
 
 
 @overload
@@ -95,10 +97,10 @@ def solar_declination_angle(date):
 
     - :py:meth:`earthkit.meteo.solar.xarray.solar_declination_angle` for xarray.DataArray
     - :py:meth:`earthkit.meteo.solar.array.solar_declination_angle` for scalar/array inputs
-      (including ``numpy.datetime64``)
 
     """
-    return dispatch(solar_declination_angle, date)
+    r = dispatch(solar_declination_angle, date)
+    return r if r is not None else array.solar_declination_angle(date)
 
 
 @overload

--- a/src/earthkit/meteo/solar/solar.py
+++ b/src/earthkit/meteo/solar/solar.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2021 ECMWF.
+# (C) Copyright 2026 ECMWF.
 #
 # This software is licensed under the terms of the Apache Licence Version 2.0
 # which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
@@ -13,12 +13,12 @@ from importlib import import_module
 from typing import TYPE_CHECKING, Any, TypeAlias, overload
 
 from earthkit.meteo.utils.decorators import _is_xarray
+from earthkit.meteo.utils.decorators import dispatch
 
 from . import array
 
 if TYPE_CHECKING:
     import datetime
-
     import xarray  # type: ignore[import]
 
 ArrayLike: TypeAlias = Any
@@ -39,8 +39,27 @@ def julian_day(date: "xarray.DataArray") -> "xarray.DataArray": ...
 @overload
 def julian_day(date: "datetime.datetime") -> float: ...
 def julian_day(date):
-    r = _dispatch_if_xarray("julian_day", date)
-    return r if r is not None else array.julian_day(date)
+    r"""Compute the Julian day (day of year as a fractional number).
+
+    Parameters
+    ----------
+    date: datetime.datetime | xarray.DataArray
+        Date/time. When ``date`` is an xarray.DataArray it is processed element-wise.
+
+    Returns
+    -------
+    float | xarray.DataArray
+        Day of year as a fractional number. January 1st at 00:00 is 0.0.
+
+    Implementations
+    ------------------------
+    :func:`julian_day` calls one of the following implementations depending on the type of the input arguments:
+
+    - :py:meth:`earthkit.meteo.solar.xarray.julian_day` for xarray.DataArray
+    - :py:meth:`earthkit.meteo.solar.array.julian_day` for array-like/scalar inputs
+
+    """
+    return dispatch(julian_day, date)
 
 
 @overload
@@ -48,8 +67,30 @@ def solar_declination_angle(date: "xarray.DataArray") -> tuple["xarray.DataArray
 @overload
 def solar_declination_angle(date: "datetime.datetime") -> tuple[float, float]: ...
 def solar_declination_angle(date):
-    r = _dispatch_if_xarray("solar_declination_angle", date)
-    return r if r is not None else array.solar_declination_angle(date)
+    r"""Compute the solar declination angle and time correction.
+
+    Parameters
+    ----------
+    date: datetime.datetime | xarray.DataArray
+        Date/time. When ``date`` is an xarray.DataArray it is processed element-wise.
+
+    Returns
+    -------
+    (float, float) | (xarray.DataArray, xarray.DataArray)
+        Tuple of
+
+        * solar declination angle (degrees)
+        * time correction (degrees)
+
+    Implementations
+    ------------------------
+    :func:`solar_declination_angle` calls one of the following implementations depending on the type of the input arguments:
+
+    - :py:meth:`earthkit.meteo.solar.xarray.solar_declination_angle` for xarray.DataArray
+    - :py:meth:`earthkit.meteo.solar.array.solar_declination_angle` for array-like/scalar inputs
+
+    """
+    return dispatch(solar_declination_angle, date)
 
 
 @overload
@@ -59,6 +100,34 @@ def cos_solar_zenith_angle(
 @overload
 def cos_solar_zenith_angle(date: "datetime.datetime", latitudes: ArrayLike, longitudes: ArrayLike): ...
 def cos_solar_zenith_angle(date, latitudes, longitudes):
+    r"""Compute the cosine of the solar zenith angle.
+
+    Parameters
+    ----------
+    date: datetime.datetime
+        Date/time (typically a scalar applying to all latitude/longitude points).
+    latitudes: array-like | xarray.DataArray
+        Latitude (degrees).
+    longitudes: array-like | xarray.DataArray
+        Longitude (degrees).
+
+    Returns
+    -------
+    array-like | xarray.DataArray
+        Cosine of the solar zenith angle (clipped to be non-negative).
+
+    Notes
+    -----
+    The result is clipped to the [0, 1] range by setting negative values to 0.
+
+    Implementations
+    ------------------------
+    :func:`cos_solar_zenith_angle` calls one of the following implementations depending on the type of the input arguments:
+
+    - :py:meth:`earthkit.meteo.solar.xarray.cos_solar_zenith_angle` when any input is xarray.DataArray
+    - :py:meth:`earthkit.meteo.solar.array.cos_solar_zenith_angle` otherwise
+
+    """
     r = _dispatch_if_xarray("cos_solar_zenith_angle", date, latitudes, longitudes)
     return r if r is not None else array.cos_solar_zenith_angle(date, latitudes, longitudes)
 
@@ -92,6 +161,37 @@ def cos_solar_zenith_angle_integrated(
     intervals_per_hour: int = 1,
     integration_order: int = 3,
 ):
+    r"""Compute the time-integrated cosine of the solar zenith angle.
+
+    Parameters
+    ----------
+    begin_date: datetime.datetime
+        Start of the integration interval.
+    end_date: datetime.datetime
+        End of the integration interval.
+    latitudes: array-like | xarray.DataArray
+        Latitude (degrees).
+    longitudes: array-like | xarray.DataArray
+        Longitude (degrees).
+    intervals_per_hour: int, optional
+        Number of sub-intervals per hour used in the numerical integration.
+    integration_order: int, optional
+        Order of the integration scheme.
+
+    Returns
+    -------
+    array-like | xarray.DataArray
+        Time-integrated cosine of the solar zenith angle.
+
+    Implementations
+    ------------------------
+    :func:`cos_solar_zenith_angle_integrated` calls one of the following implementations depending on the type
+    of the input arguments:
+
+    - :py:meth:`earthkit.meteo.solar.xarray.cos_solar_zenith_angle_integrated` when any input is xarray.DataArray
+    - :py:meth:`earthkit.meteo.solar.array.cos_solar_zenith_angle_integrated` otherwise
+
+    """
     r = _dispatch_if_xarray(
         "cos_solar_zenith_angle_integrated",
         begin_date,
@@ -120,6 +220,26 @@ def incoming_solar_radiation(date: "xarray.DataArray") -> "xarray.DataArray": ..
 @overload
 def incoming_solar_radiation(date: "datetime.datetime") -> float: ...
 def incoming_solar_radiation(date):
+    r"""Compute the incoming solar radiation at the top of the atmosphere (TOA).
+
+    Parameters
+    ----------
+    date: datetime.datetime | xarray.DataArray
+        Date/time. When ``date`` is an xarray.DataArray it is processed element-wise.
+
+    Returns
+    -------
+    float | xarray.DataArray
+        Incoming solar radiation at TOA.
+
+    Implementations
+    ------------------------
+    :func:`incoming_solar_radiation` calls one of the following implementations depending on the type of the input arguments:
+
+    - :py:meth:`earthkit.meteo.solar.xarray.incoming_solar_radiation` for xarray.DataArray
+    - :py:meth:`earthkit.meteo.solar.array.incoming_solar_radiation` for array-like/scalar inputs
+
+    """
     r = _dispatch_if_xarray("incoming_solar_radiation", date)
     return r if r is not None else array.incoming_solar_radiation(date)
 
@@ -153,6 +273,37 @@ def toa_incident_solar_radiation(
     intervals_per_hour: int = 1,
     integration_order: int = 3,
 ):
+    r"""Compute the time-integrated incident solar radiation at the top of the atmosphere (TOA).
+
+    Parameters
+    ----------
+    begin_date: datetime.datetime
+        Start of the integration interval.
+    end_date: datetime.datetime
+        End of the integration interval.
+    latitudes: array-like | xarray.DataArray
+        Latitude (degrees).
+    longitudes: array-like | xarray.DataArray
+        Longitude (degrees).
+    intervals_per_hour: int, optional
+        Number of sub-intervals per hour used in the numerical integration.
+    integration_order: int, optional
+        Order of the integration scheme.
+
+    Returns
+    -------
+    array-like | xarray.DataArray
+        Time-integrated incident solar radiation at TOA.
+
+    Implementations
+    ------------------------
+    :func:`toa_incident_solar_radiation` calls one of the following implementations depending on the type
+    of the input arguments:
+
+    - :py:meth:`earthkit.meteo.solar.xarray.toa_incident_solar_radiation` when any input is xarray.DataArray
+    - :py:meth:`earthkit.meteo.solar.array.toa_incident_solar_radiation` otherwise
+
+    """
     r = _dispatch_if_xarray(
         "toa_incident_solar_radiation",
         begin_date,

--- a/src/earthkit/meteo/solar/solar.py
+++ b/src/earthkit/meteo/solar/solar.py
@@ -7,28 +7,170 @@
 # nor does it submit to any jurisdiction.
 #
 
+from __future__ import annotations
+
+from importlib import import_module
+from typing import TYPE_CHECKING, Any, TypeAlias, overload
+
+from earthkit.meteo.utils.decorators import _is_xarray
+
 from . import array
 
+if TYPE_CHECKING:
+    import datetime
 
-def julian_day(*args, **kwargs):
-    return array.julian_day(*args, **kwargs)
+    import xarray  # type: ignore[import]
 
-
-def solar_declination_angle(*args, **kwargs):
-    return array.solar_declination_angle(*args, **kwargs)
-
-
-def cos_solar_zenith_angle(*args, **kwargs):
-    return array.cos_solar_zenith_angle(*args, **kwargs)
+ArrayLike: TypeAlias = Any
 
 
-def cos_solar_zenith_angle_integrated(*args, **kwargs):
-    return array.cos_solar_zenith_angle_integrated(*args, **kwargs)
+def _dispatch_if_xarray(func_name: str, *args: Any, **kwargs: Any) -> Any | None:
+    # Solar functions often take `date` as the first argument (scalar datetime),
+    # while lat/lon are xarray objects. The default `dispatch()` only checks args[0],
+    # so we do a custom dispatch: if *any* positional arg is xarray, use xarray impl.
+    if any(_is_xarray(a) for a in args):
+        module = import_module(__name__.rsplit(".", 1)[0] + ".xarray")
+        return getattr(module, func_name)(*args, **kwargs)
+    return None
 
 
-def incoming_solar_radiation(*args, **kwargs):
-    return array.incoming_solar_radiation(*args, **kwargs)
+@overload
+def julian_day(date: "xarray.DataArray") -> "xarray.DataArray": ...
+@overload
+def julian_day(date: "datetime.datetime") -> float: ...
+def julian_day(date):
+    r = _dispatch_if_xarray("julian_day", date)
+    return r if r is not None else array.julian_day(date)
 
 
-def toa_incident_solar_radiation(*args, **kwargs):
-    return array.toa_incident_solar_radiation(*args, **kwargs)
+@overload
+def solar_declination_angle(date: "xarray.DataArray") -> tuple["xarray.DataArray", "xarray.DataArray"]: ...
+@overload
+def solar_declination_angle(date: "datetime.datetime") -> tuple[float, float]: ...
+def solar_declination_angle(date):
+    r = _dispatch_if_xarray("solar_declination_angle", date)
+    return r if r is not None else array.solar_declination_angle(date)
+
+
+@overload
+def cos_solar_zenith_angle(
+    date: "datetime.datetime", latitudes: "xarray.DataArray", longitudes: "xarray.DataArray"
+) -> "xarray.DataArray": ...
+@overload
+def cos_solar_zenith_angle(date: "datetime.datetime", latitudes: ArrayLike, longitudes: ArrayLike): ...
+def cos_solar_zenith_angle(date, latitudes, longitudes):
+    r = _dispatch_if_xarray("cos_solar_zenith_angle", date, latitudes, longitudes)
+    return r if r is not None else array.cos_solar_zenith_angle(date, latitudes, longitudes)
+
+
+@overload
+def cos_solar_zenith_angle_integrated(
+    begin_date: "datetime.datetime",
+    end_date: "datetime.datetime",
+    latitudes: "xarray.DataArray",
+    longitudes: "xarray.DataArray",
+    *,
+    intervals_per_hour: int = 1,
+    integration_order: int = 3,
+) -> "xarray.DataArray": ...
+@overload
+def cos_solar_zenith_angle_integrated(
+    begin_date: "datetime.datetime",
+    end_date: "datetime.datetime",
+    latitudes: ArrayLike,
+    longitudes: ArrayLike,
+    *,
+    intervals_per_hour: int = 1,
+    integration_order: int = 3,
+): ...
+def cos_solar_zenith_angle_integrated(
+    begin_date,
+    end_date,
+    latitudes,
+    longitudes,
+    *,
+    intervals_per_hour: int = 1,
+    integration_order: int = 3,
+):
+    r = _dispatch_if_xarray(
+        "cos_solar_zenith_angle_integrated",
+        begin_date,
+        end_date,
+        latitudes,
+        longitudes,
+        intervals_per_hour=intervals_per_hour,
+        integration_order=integration_order,
+    )
+    return (
+        r
+        if r is not None
+        else array.cos_solar_zenith_angle_integrated(
+            begin_date,
+            end_date,
+            latitudes,
+            longitudes,
+            intervals_per_hour=intervals_per_hour,
+            integration_order=integration_order,
+        )
+    )
+
+
+@overload
+def incoming_solar_radiation(date: "xarray.DataArray") -> "xarray.DataArray": ...
+@overload
+def incoming_solar_radiation(date: "datetime.datetime") -> float: ...
+def incoming_solar_radiation(date):
+    r = _dispatch_if_xarray("incoming_solar_radiation", date)
+    return r if r is not None else array.incoming_solar_radiation(date)
+
+
+@overload
+def toa_incident_solar_radiation(
+    begin_date: "datetime.datetime",
+    end_date: "datetime.datetime",
+    latitudes: "xarray.DataArray",
+    longitudes: "xarray.DataArray",
+    *,
+    intervals_per_hour: int = 1,
+    integration_order: int = 3,
+) -> "xarray.DataArray": ...
+@overload
+def toa_incident_solar_radiation(
+    begin_date: "datetime.datetime",
+    end_date: "datetime.datetime",
+    latitudes: ArrayLike,
+    longitudes: ArrayLike,
+    *,
+    intervals_per_hour: int = 1,
+    integration_order: int = 3,
+): ...
+def toa_incident_solar_radiation(
+    begin_date,
+    end_date,
+    latitudes,
+    longitudes,
+    *,
+    intervals_per_hour: int = 1,
+    integration_order: int = 3,
+):
+    r = _dispatch_if_xarray(
+        "toa_incident_solar_radiation",
+        begin_date,
+        end_date,
+        latitudes,
+        longitudes,
+        intervals_per_hour=intervals_per_hour,
+        integration_order=integration_order,
+    )
+    return (
+        r
+        if r is not None
+        else array.toa_incident_solar_radiation(
+            begin_date,
+            end_date,
+            latitudes,
+            longitudes,
+            intervals_per_hour=intervals_per_hour,
+            integration_order=integration_order,
+        )
+    )

--- a/src/earthkit/meteo/solar/solar.py
+++ b/src/earthkit/meteo/solar/solar.py
@@ -19,7 +19,10 @@ from . import array
 
 if TYPE_CHECKING:
     import datetime
+    import numpy as np
     import xarray  # type: ignore[import]
+
+DateLike: TypeAlias = datetime.datetime | np.datetime64
 
 ArrayLike: TypeAlias = Any
 
@@ -37,7 +40,7 @@ def _dispatch_if_xarray(func_name: str, *args: Any, **kwargs: Any) -> Any | None
 @overload
 def julian_day(date: "xarray.DataArray") -> "xarray.DataArray": ...
 @overload
-def julian_day(date: "datetime.datetime") -> float: ...
+def julian_day(date: DateLike) -> float: ...
 def julian_day(date):
     r"""Compute the Julian day (day of year as a fractional number).
 
@@ -65,7 +68,7 @@ def julian_day(date):
 @overload
 def solar_declination_angle(date: "xarray.DataArray") -> tuple["xarray.DataArray", "xarray.DataArray"]: ...
 @overload
-def solar_declination_angle(date: "datetime.datetime") -> tuple[float, float]: ...
+def solar_declination_angle(date: DateLike) -> tuple[float, float]: ...
 def solar_declination_angle(date):
     r"""Compute the solar declination angle and time correction.
 
@@ -218,7 +221,7 @@ def cos_solar_zenith_angle_integrated(
 @overload
 def incoming_solar_radiation(date: "xarray.DataArray") -> "xarray.DataArray": ...
 @overload
-def incoming_solar_radiation(date: "datetime.datetime") -> float: ...
+def incoming_solar_radiation(date: DateLike) -> float: ...
 def incoming_solar_radiation(date):
     r"""Compute the incoming solar radiation at the top of the atmosphere (TOA).
 

--- a/src/earthkit/meteo/solar/solar.py
+++ b/src/earthkit/meteo/solar/solar.py
@@ -10,7 +10,10 @@
 from __future__ import annotations
 
 from importlib import import_module
-from typing import TYPE_CHECKING, Any, TypeAlias, overload
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import TypeAlias
+from typing import overload
 
 from earthkit.meteo.utils.decorators import _is_xarray
 from earthkit.meteo.utils.decorators import dispatch
@@ -19,18 +22,18 @@ from . import array
 
 if TYPE_CHECKING:
     import datetime
+
     import numpy as np
     import xarray  # type: ignore[import]
 
-DateLike: TypeAlias = datetime.datetime | np.datetime64
+# NOTE: this must exist at runtime too (don’t put it under TYPE_CHECKING)
+DateLike: TypeAlias = "datetime.datetime | np.datetime64"
 
 ArrayLike: TypeAlias = Any
 
 
 def _dispatch_if_xarray(func_name: str, *args: Any, **kwargs: Any) -> Any | None:
-    # Solar functions often take `date` as the first argument (scalar datetime),
-    # while lat/lon are xarray objects. The default `dispatch()` only checks args[0],
-    # so we do a custom dispatch: if *any* positional arg is xarray, use xarray impl.
+    """Dispatch to the xarray implementation if any positional argument is xarray."""
     if any(_is_xarray(a) for a in args):
         module = import_module(__name__.rsplit(".", 1)[0] + ".xarray")
         return getattr(module, func_name)(*args, **kwargs)
@@ -46,7 +49,7 @@ def julian_day(date):
 
     Parameters
     ----------
-    date: datetime.datetime | xarray.DataArray
+    date: datetime.datetime | numpy.datetime64 | xarray.DataArray
         Date/time. When ``date`` is an xarray.DataArray it is processed element-wise.
 
     Returns
@@ -59,7 +62,8 @@ def julian_day(date):
     :func:`julian_day` calls one of the following implementations depending on the type of the input arguments:
 
     - :py:meth:`earthkit.meteo.solar.xarray.julian_day` for xarray.DataArray
-    - :py:meth:`earthkit.meteo.solar.array.julian_day` for array-like/scalar inputs
+    - :py:meth:`earthkit.meteo.solar.array.julian_day` for scalar/array inputs
+      (including ``numpy.datetime64``)
 
     """
     return dispatch(julian_day, date)
@@ -74,8 +78,8 @@ def solar_declination_angle(date):
 
     Parameters
     ----------
-    date: datetime.datetime | xarray.DataArray
-        Date/time. When ``date`` is an xarray.DataArray it is processed element-wise.
+    date: datetime.datetime | numpy.datetime64 | xarray.DataArray
+        Date/time.
 
     Returns
     -------
@@ -90,7 +94,8 @@ def solar_declination_angle(date):
     :func:`solar_declination_angle` calls one of the following implementations depending on the type of the input arguments:
 
     - :py:meth:`earthkit.meteo.solar.xarray.solar_declination_angle` for xarray.DataArray
-    - :py:meth:`earthkit.meteo.solar.array.solar_declination_angle` for array-like/scalar inputs
+    - :py:meth:`earthkit.meteo.solar.array.solar_declination_angle` for scalar/array inputs
+      (including ``numpy.datetime64``)
 
     """
     return dispatch(solar_declination_angle, date)
@@ -98,16 +103,16 @@ def solar_declination_angle(date):
 
 @overload
 def cos_solar_zenith_angle(
-    date: "datetime.datetime", latitudes: "xarray.DataArray", longitudes: "xarray.DataArray"
+    date: DateLike, latitudes: "xarray.DataArray", longitudes: "xarray.DataArray"
 ) -> "xarray.DataArray": ...
 @overload
-def cos_solar_zenith_angle(date: "datetime.datetime", latitudes: ArrayLike, longitudes: ArrayLike): ...
+def cos_solar_zenith_angle(date: DateLike, latitudes: ArrayLike, longitudes: ArrayLike): ...
 def cos_solar_zenith_angle(date, latitudes, longitudes):
     r"""Compute the cosine of the solar zenith angle.
 
     Parameters
     ----------
-    date: datetime.datetime
+    date: datetime.datetime | numpy.datetime64
         Date/time (typically a scalar applying to all latitude/longitude points).
     latitudes: array-like | xarray.DataArray
         Latitude (degrees).
@@ -121,7 +126,7 @@ def cos_solar_zenith_angle(date, latitudes, longitudes):
 
     Notes
     -----
-    The result is clipped to the [0, 1] range by setting negative values to 0.
+    The result is clipped by setting negative values to 0.
 
     Implementations
     ------------------------
@@ -137,8 +142,8 @@ def cos_solar_zenith_angle(date, latitudes, longitudes):
 
 @overload
 def cos_solar_zenith_angle_integrated(
-    begin_date: "datetime.datetime",
-    end_date: "datetime.datetime",
+    begin_date: DateLike,
+    end_date: DateLike,
     latitudes: "xarray.DataArray",
     longitudes: "xarray.DataArray",
     *,
@@ -147,8 +152,8 @@ def cos_solar_zenith_angle_integrated(
 ) -> "xarray.DataArray": ...
 @overload
 def cos_solar_zenith_angle_integrated(
-    begin_date: "datetime.datetime",
-    end_date: "datetime.datetime",
+    begin_date: DateLike,
+    end_date: DateLike,
     latitudes: ArrayLike,
     longitudes: ArrayLike,
     *,
@@ -168,9 +173,9 @@ def cos_solar_zenith_angle_integrated(
 
     Parameters
     ----------
-    begin_date: datetime.datetime
+    begin_date: datetime.datetime | numpy.datetime64
         Start of the integration interval.
-    end_date: datetime.datetime
+    end_date: datetime.datetime | numpy.datetime64
         End of the integration interval.
     latitudes: array-like | xarray.DataArray
         Latitude (degrees).
@@ -227,8 +232,8 @@ def incoming_solar_radiation(date):
 
     Parameters
     ----------
-    date: datetime.datetime | xarray.DataArray
-        Date/time. When ``date`` is an xarray.DataArray it is processed element-wise.
+    date: datetime.datetime | numpy.datetime64 | xarray.DataArray
+        Date/time.
 
     Returns
     -------
@@ -240,17 +245,17 @@ def incoming_solar_radiation(date):
     :func:`incoming_solar_radiation` calls one of the following implementations depending on the type of the input arguments:
 
     - :py:meth:`earthkit.meteo.solar.xarray.incoming_solar_radiation` for xarray.DataArray
-    - :py:meth:`earthkit.meteo.solar.array.incoming_solar_radiation` for array-like/scalar inputs
+    - :py:meth:`earthkit.meteo.solar.array.incoming_solar_radiation` for scalar/array inputs
+      (including ``numpy.datetime64``)
 
     """
-    r = _dispatch_if_xarray("incoming_solar_radiation", date)
-    return r if r is not None else array.incoming_solar_radiation(date)
+    return dispatch(incoming_solar_radiation, date)
 
 
 @overload
 def toa_incident_solar_radiation(
-    begin_date: "datetime.datetime",
-    end_date: "datetime.datetime",
+    begin_date: DateLike,
+    end_date: DateLike,
     latitudes: "xarray.DataArray",
     longitudes: "xarray.DataArray",
     *,
@@ -259,8 +264,8 @@ def toa_incident_solar_radiation(
 ) -> "xarray.DataArray": ...
 @overload
 def toa_incident_solar_radiation(
-    begin_date: "datetime.datetime",
-    end_date: "datetime.datetime",
+    begin_date: DateLike,
+    end_date: DateLike,
     latitudes: ArrayLike,
     longitudes: ArrayLike,
     *,
@@ -280,9 +285,9 @@ def toa_incident_solar_radiation(
 
     Parameters
     ----------
-    begin_date: datetime.datetime
+    begin_date: datetime.datetime | numpy.datetime64
         Start of the integration interval.
-    end_date: datetime.datetime
+    end_date: datetime.datetime | numpy.datetime64
         End of the integration interval.
     latitudes: array-like | xarray.DataArray
         Latitude (degrees).

--- a/src/earthkit/meteo/solar/xarray/__init__.py
+++ b/src/earthkit/meteo/solar/xarray/__init__.py
@@ -1,0 +1,12 @@
+# (C) Copyright 2026 ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+#
+
+"""Solar computation functions operating on xarray objects."""
+
+from .solar import *  # noqa

--- a/src/earthkit/meteo/solar/xarray/solar.py
+++ b/src/earthkit/meteo/solar/xarray/solar.py
@@ -28,12 +28,6 @@ def julian_day(date: xr.DataArray) -> xr.DataArray:
     -------
     xarray.DataArray
         Day of year as a fractional number. January 1st at 00:00 is 0.0.
-
-    Notes
-    -----
-    Xarray typically stores time values as ``numpy.datetime64``. The underlying
-    array implementation must be able to handle that representation (or convert
-    to ``datetime.datetime``).
     """
     return xarray_ufunc(array.julian_day, date, xarray_ufunc_kwargs={"vectorize": True})
 
@@ -153,12 +147,6 @@ def incoming_solar_radiation(date: xr.DataArray) -> xr.DataArray:
     -------
     xarray.DataArray
         Incoming solar radiation at TOA.
-
-    Notes
-    -----
-    Xarray typically stores time values as ``numpy.datetime64``. The underlying
-    array implementation must be able to handle that representation (or convert
-    to ``datetime.datetime``).
     """
     return xarray_ufunc(array.incoming_solar_radiation, date, xarray_ufunc_kwargs={"vectorize": True})
 

--- a/src/earthkit/meteo/solar/xarray/solar.py
+++ b/src/earthkit/meteo/solar/xarray/solar.py
@@ -1,0 +1,82 @@
+# (C) Copyright 2021 ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+#
+
+from __future__ import annotations
+
+import xarray as xr
+
+from earthkit.meteo.utils.decorators import xarray_ufunc
+
+from .. import array
+
+
+def julian_day(date: xr.DataArray) -> xr.DataArray:
+    # Elementwise over `date` (typically a time coordinate/array).
+    # NOTE: if `date` is numpy.datetime64, the underlying array implementation
+    # must support that (or convert).
+    return xarray_ufunc(array.julian_day, date, xarray_ufunc_kwargs={"vectorize": True})
+
+
+def solar_declination_angle(date: xr.DataArray) -> tuple[xr.DataArray, xr.DataArray]:
+    return xarray_ufunc(array.solar_declination_angle, date, xarray_ufunc_kwargs={"vectorize": True})
+
+
+def cos_solar_zenith_angle(date, latitudes: xr.DataArray, longitudes: xr.DataArray) -> xr.DataArray:
+    def _impl(lat, lon):
+        return array.cos_solar_zenith_angle(date, lat, lon)
+
+    return xarray_ufunc(_impl, latitudes, longitudes)
+
+
+def cos_solar_zenith_angle_integrated(
+    begin_date,
+    end_date,
+    latitudes: xr.DataArray,
+    longitudes: xr.DataArray,
+    *,
+    intervals_per_hour: int = 1,
+    integration_order: int = 3,
+) -> xr.DataArray:
+    def _impl(lat, lon):
+        return array.cos_solar_zenith_angle_integrated(
+            begin_date,
+            end_date,
+            lat,
+            lon,
+            intervals_per_hour=intervals_per_hour,
+            integration_order=integration_order,
+        )
+
+    return xarray_ufunc(_impl, latitudes, longitudes)
+
+
+def incoming_solar_radiation(date: xr.DataArray) -> xr.DataArray:
+    return xarray_ufunc(array.incoming_solar_radiation, date, xarray_ufunc_kwargs={"vectorize": True})
+
+
+def toa_incident_solar_radiation(
+    begin_date,
+    end_date,
+    latitudes: xr.DataArray,
+    longitudes: xr.DataArray,
+    *,
+    intervals_per_hour: int = 1,
+    integration_order: int = 3,
+) -> xr.DataArray:
+    def _impl(lat, lon):
+        return array.toa_incident_solar_radiation(
+            begin_date,
+            end_date,
+            lat,
+            lon,
+            intervals_per_hour=intervals_per_hour,
+            integration_order=integration_order,
+        )
+
+    return xarray_ufunc(_impl, latitudes, longitudes)

--- a/src/earthkit/meteo/solar/xarray/solar.py
+++ b/src/earthkit/meteo/solar/xarray/solar.py
@@ -31,8 +31,9 @@ def julian_day(date: xr.DataArray) -> xr.DataArray:
 
     Notes
     -----
-    If ``date`` uses a numpy datetime64 dtype, the underlying array implementation must be able to
-    handle that representation (or the values must be converted to ``datetime.datetime``).
+    Xarray typically stores time values as ``numpy.datetime64``. The underlying
+    array implementation must be able to handle that representation (or convert
+    to ``datetime.datetime``).
     """
     return xarray_ufunc(array.julian_day, date, xarray_ufunc_kwargs={"vectorize": True})
 
@@ -52,8 +53,19 @@ def solar_declination_angle(date: xr.DataArray) -> tuple[xr.DataArray, xr.DataAr
     xarray.DataArray
         Time correction (degrees).
 
+    Notes
+    -----
+    This function returns two outputs. We explicitly provide ``output_dtypes`` to
+    ensure xarray correctly allocates the outputs when vectorizing.
     """
-    return xarray_ufunc(array.solar_declination_angle, date, xarray_ufunc_kwargs={"vectorize": True})
+    return xarray_ufunc(
+        array.solar_declination_angle,
+        date,
+        xarray_ufunc_kwargs={
+            "vectorize": True,
+            "output_dtypes": [float, float],
+        },
+    )
 
 
 def cos_solar_zenith_angle(date, latitudes: xr.DataArray, longitudes: xr.DataArray) -> xr.DataArray:
@@ -114,7 +126,6 @@ def cos_solar_zenith_angle_integrated(
     -------
     xarray.DataArray
         Time-integrated cosine of the solar zenith angle.
-
     """
 
     def _impl(lat, lon):
@@ -145,8 +156,9 @@ def incoming_solar_radiation(date: xr.DataArray) -> xr.DataArray:
 
     Notes
     -----
-    If ``date`` uses a numpy datetime64 dtype, the underlying array implementation must be able to
-    handle that representation (or the values must be converted to ``datetime.datetime``).
+    Xarray typically stores time values as ``numpy.datetime64``. The underlying
+    array implementation must be able to handle that representation (or convert
+    to ``datetime.datetime``).
     """
     return xarray_ufunc(array.incoming_solar_radiation, date, xarray_ufunc_kwargs={"vectorize": True})
 
@@ -181,7 +193,6 @@ def toa_incident_solar_radiation(
     -------
     xarray.DataArray
         Time-integrated incident solar radiation at TOA.
-
     """
 
     def _impl(lat, lon):

--- a/src/earthkit/meteo/solar/xarray/solar.py
+++ b/src/earthkit/meteo/solar/xarray/solar.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2021 ECMWF.
+# (C) Copyright 2026 ECMWF.
 #
 # This software is licensed under the terms of the Apache Licence Version 2.0
 # which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
@@ -17,17 +17,67 @@ from .. import array
 
 
 def julian_day(date: xr.DataArray) -> xr.DataArray:
-    # Elementwise over `date` (typically a time coordinate/array).
-    # NOTE: if `date` is numpy.datetime64, the underlying array implementation
-    # must support that (or convert).
+    r"""Compute the Julian day (day of year as a fractional number).
+
+    Parameters
+    ----------
+    date: xarray.DataArray
+        Date/time. Computation is performed element-wise.
+
+    Returns
+    -------
+    xarray.DataArray
+        Day of year as a fractional number. January 1st at 00:00 is 0.0.
+
+    Notes
+    -----
+    If ``date`` uses a numpy datetime64 dtype, the underlying array implementation must be able to
+    handle that representation (or the values must be converted to ``datetime.datetime``).
+    """
     return xarray_ufunc(array.julian_day, date, xarray_ufunc_kwargs={"vectorize": True})
 
 
 def solar_declination_angle(date: xr.DataArray) -> tuple[xr.DataArray, xr.DataArray]:
+    r"""Compute the solar declination angle and time correction.
+
+    Parameters
+    ----------
+    date: xarray.DataArray
+        Date/time. Computation is performed element-wise.
+
+    Returns
+    -------
+    xarray.DataArray
+        Solar declination angle (degrees).
+    xarray.DataArray
+        Time correction (degrees).
+
+    """
     return xarray_ufunc(array.solar_declination_angle, date, xarray_ufunc_kwargs={"vectorize": True})
 
 
 def cos_solar_zenith_angle(date, latitudes: xr.DataArray, longitudes: xr.DataArray) -> xr.DataArray:
+    r"""Compute the cosine of the solar zenith angle.
+
+    Parameters
+    ----------
+    date: datetime.datetime
+        Date/time (typically a scalar applying to all latitude/longitude points).
+    latitudes: xarray.DataArray
+        Latitude (degrees).
+    longitudes: xarray.DataArray
+        Longitude (degrees).
+
+    Returns
+    -------
+    xarray.DataArray
+        Cosine of the solar zenith angle (clipped to be non-negative).
+
+    Notes
+    -----
+    The result is clipped to the [0, 1] range by setting negative values to 0.
+    """
+
     def _impl(lat, lon):
         return array.cos_solar_zenith_angle(date, lat, lon)
 
@@ -43,6 +93,30 @@ def cos_solar_zenith_angle_integrated(
     intervals_per_hour: int = 1,
     integration_order: int = 3,
 ) -> xr.DataArray:
+    r"""Compute the time-integrated cosine of the solar zenith angle.
+
+    Parameters
+    ----------
+    begin_date: datetime.datetime
+        Start of the integration interval.
+    end_date: datetime.datetime
+        End of the integration interval.
+    latitudes: xarray.DataArray
+        Latitude (degrees).
+    longitudes: xarray.DataArray
+        Longitude (degrees).
+    intervals_per_hour: int, optional
+        Number of sub-intervals per hour used in the numerical integration.
+    integration_order: int, optional
+        Order of the integration scheme.
+
+    Returns
+    -------
+    xarray.DataArray
+        Time-integrated cosine of the solar zenith angle.
+
+    """
+
     def _impl(lat, lon):
         return array.cos_solar_zenith_angle_integrated(
             begin_date,
@@ -57,6 +131,23 @@ def cos_solar_zenith_angle_integrated(
 
 
 def incoming_solar_radiation(date: xr.DataArray) -> xr.DataArray:
+    r"""Compute the incoming solar radiation at the top of the atmosphere (TOA).
+
+    Parameters
+    ----------
+    date: xarray.DataArray
+        Date/time. Computation is performed element-wise.
+
+    Returns
+    -------
+    xarray.DataArray
+        Incoming solar radiation at TOA.
+
+    Notes
+    -----
+    If ``date`` uses a numpy datetime64 dtype, the underlying array implementation must be able to
+    handle that representation (or the values must be converted to ``datetime.datetime``).
+    """
     return xarray_ufunc(array.incoming_solar_radiation, date, xarray_ufunc_kwargs={"vectorize": True})
 
 
@@ -69,6 +160,30 @@ def toa_incident_solar_radiation(
     intervals_per_hour: int = 1,
     integration_order: int = 3,
 ) -> xr.DataArray:
+    r"""Compute the time-integrated incident solar radiation at the top of the atmosphere (TOA).
+
+    Parameters
+    ----------
+    begin_date: datetime.datetime
+        Start of the integration interval.
+    end_date: datetime.datetime
+        End of the integration interval.
+    latitudes: xarray.DataArray
+        Latitude (degrees).
+    longitudes: xarray.DataArray
+        Longitude (degrees).
+    intervals_per_hour: int, optional
+        Number of sub-intervals per hour used in the numerical integration.
+    integration_order: int, optional
+        Order of the integration scheme.
+
+    Returns
+    -------
+    xarray.DataArray
+        Time-integrated incident solar radiation at TOA.
+
+    """
+
     def _impl(lat, lon):
         return array.toa_incident_solar_radiation(
             begin_date,

--- a/tests/solar/test_solar_array.py
+++ b/tests/solar/test_solar_array.py
@@ -14,7 +14,7 @@ import numpy as np
 import pytest
 from earthkit.utils.array.testing import NAMESPACE_DEVICES
 
-from earthkit.meteo import solar
+from earthkit.meteo.solar.array import solar
 
 
 @pytest.mark.parametrize(

--- a/tests/solar/test_solar_xarray.py
+++ b/tests/solar/test_solar_xarray.py
@@ -1,0 +1,136 @@
+# (C) Copyright 2026 ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+#
+
+import datetime
+
+import numpy as np
+import pytest
+
+import earthkit.meteo.solar.array as array_solar
+from earthkit.meteo import solar
+from earthkit.meteo.utils.testing import NO_XARRAY
+
+np.set_printoptions(formatter={"float_kind": "{:.10f}".format})
+
+pytestmark = pytest.mark.skipif(NO_XARRAY, reason="xarray is not installed")
+
+
+def _da(values):
+    import xarray as xr
+
+    return xr.DataArray(np.asarray(values))
+
+
+@pytest.mark.skipif(NO_XARRAY, reason="xarray is not installed")
+def test_xr_julian_day():
+    dates = [
+        datetime.datetime(2024, 4, 22, 0, 0, 0),
+        datetime.datetime(2024, 4, 22, 12, 0, 0),
+    ]
+
+    da = _da(dates)
+    assert np.issubdtype(da.dtype, np.datetime64)
+
+    v = solar.julian_day(da)
+    assert hasattr(v, "values")
+    assert np.allclose(v.values, np.asarray([112.0, 112.5]))
+
+
+@pytest.mark.skipif(NO_XARRAY, reason="xarray is not installed")
+def test_xr_solar_declination_angle():
+    dates = [
+        datetime.datetime(2024, 4, 22, 0, 0, 0),
+        datetime.datetime(2024, 4, 22, 12, 0, 0),
+    ]
+
+    da = _da(dates)
+    assert np.issubdtype(da.dtype, np.datetime64)
+
+    decl, tc = solar.solar_declination_angle(da)
+
+    decl_ref = np.asarray([12.235799080498582, 12.403019177270453])
+    tc_ref = np.asarray([0.40707190497656276, 0.43253901867797273])
+
+    assert np.allclose(decl.values, decl_ref)
+    assert np.allclose(tc.values, tc_ref)
+
+
+@pytest.mark.skipif(NO_XARRAY, reason="xarray is not installed")
+def test_xr_incoming_solar_radiation():
+    dates = [datetime.datetime(2024, 4, 22, 12, 0, 0)]
+
+    da = _da(dates)
+    assert np.issubdtype(da.dtype, np.datetime64)
+
+    v = solar.incoming_solar_radiation(da)
+    assert np.allclose(v.values, np.asarray([4833557.3088814365]))
+
+
+@pytest.mark.skipif(NO_XARRAY, reason="xarray is not installed")
+def test_xr_cos_solar_zenith_angle():
+    import xarray as xr
+
+    date = datetime.datetime(2024, 4, 22, 12, 0, 0)
+    lat = xr.DataArray(np.asarray([40.0, 41.0]), dims=("point",))
+    lon = xr.DataArray(np.asarray([18.0, 19.0]), dims=("point",))
+
+    v = solar.cos_solar_zenith_angle(date, lat, lon)
+
+    v_ref = array_solar.cos_solar_zenith_angle(date, lat.values, lon.values)
+    assert np.allclose(v.values, np.asarray(v_ref))
+
+
+@pytest.mark.skipif(NO_XARRAY, reason="xarray is not installed")
+@pytest.mark.parametrize("integration_order", [1, 2, 3, 4])
+def test_xr_cos_solar_zenith_angle_integrated(integration_order):
+    import xarray as xr
+
+    begin_date = datetime.datetime(2024, 4, 22)
+    end_date = datetime.datetime(2024, 4, 23)
+    lat = xr.DataArray(np.asarray([40.0]), dims=("point",))
+    lon = xr.DataArray(np.asarray([18.0]), dims=("point",))
+
+    v = solar.cos_solar_zenith_angle_integrated(
+        begin_date,
+        end_date,
+        lat,
+        lon,
+        integration_order=integration_order,
+    )
+
+    v_ref = array_solar.cos_solar_zenith_angle_integrated(
+        begin_date,
+        end_date,
+        lat.values,
+        lon.values,
+        integration_order=integration_order,
+    )
+
+    assert np.allclose(v.values, np.asarray(v_ref))
+
+
+@pytest.mark.skipif(NO_XARRAY, reason="xarray is not installed")
+def test_xr_toa_incident_solar_radiation():
+    import xarray as xr
+
+    begin_date = datetime.datetime(2024, 4, 22)
+    end_date = datetime.datetime(2024, 4, 23)
+    lat = xr.DataArray(np.asarray([40.0]), dims=("point",))
+    lon = xr.DataArray(np.asarray([18.0]), dims=("point",))
+
+    v = solar.toa_incident_solar_radiation(begin_date, end_date, lat, lon)
+
+    v_ref = array_solar.toa_incident_solar_radiation(
+        begin_date,
+        end_date,
+        lat.values,
+        lon.values,
+    )
+
+    assert np.allclose(v.values, np.asarray(v_ref))


### PR DESCRIPTION
### Description
This PR adds xarray support to the `earthkit.meteo.solar` module.
#### Changes
- Added solar.xarray backend implementing all solar functions using xarray_ufunc.
- Added _dispatch_if_xarray helper to ensure correct dispatch when xarray objects are not the first argument (e.g. scalar date with xarray lat/lon).
- Extended array backend to support numpy.datetime64 scalars and arrays for compatibility with xarray.
- Updated type hints and docstrings to include numpy.datetime64.
- Added tests to validate xarray behaviour and ensure consistency with array backend.

Addresses https://github.com/ecmwf/earthkit-meteo/issues/99.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 