### PR TITLE
Use dim kwargs in vertical array level interface

### DIFF
--- a/src/earthkit/meteo/vertical/array/monotonic.py
+++ b/src/earthkit/meteo/vertical/array/monotonic.py
@@ -57,7 +57,7 @@ class MonotonicInterpolator:
         aux_min_level_coord=None,
         aux_max_level_data=None,
         aux_max_level_coord=None,
-        vertical_axis=0,
+        vertical_dim=0,
     ):
 
         if interpolation not in ["linear", "log", "nearest"]:
@@ -72,13 +72,13 @@ class MonotonicInterpolator:
         data = xp.asarray(data)
 
         # move the vertical axis to the first position for easier processing
-        if vertical_axis != 0:
+        if vertical_dim != 0:
             if data.ndim > 1:
-                data = xp.moveaxis(data, vertical_axis, 0)
+                data = xp.moveaxis(data, vertical_dim, 0)
             if coord.ndim > 1:
-                coord = xp.moveaxis(coord, vertical_axis, 0)
+                coord = xp.moveaxis(coord, vertical_dim, 0)
             if target_coord.ndim > 1:
-                target_coord = xp.moveaxis(target_coord, vertical_axis, 0)
+                target_coord = xp.moveaxis(target_coord, vertical_dim, 0)
 
         # Ensure levels are in descending order with respect to the values in the first
         # dimension of coord
@@ -177,8 +177,8 @@ class MonotonicInterpolator:
             return self.simple_compute(res)
 
         # move back the vertical axis to the original position
-        if vertical_axis != 0 and res.ndim > 1:
-            res = xp.moveaxis(res, 0, vertical_axis)
+        if vertical_dim != 0 and res.ndim > 1:
+            res = xp.moveaxis(res, 0, vertical_dim)
 
         return res
 

--- a/src/earthkit/meteo/vertical/array/vertical.py
+++ b/src/earthkit/meteo/vertical/array/vertical.py
@@ -516,7 +516,7 @@ def pressure_on_hybrid_levels(
     levels=None,
     alpha_top="ifs",
     output="full",
-    vertical_axis=0,
+    vertical_dim=0,
 ) -> ArrayLike:
     r"""Compute pressure and related parameters on hybrid (IFS model) levels.
 
@@ -567,7 +567,7 @@ def pressure_on_hybrid_levels(
           thickness on full-levels. See
           :func:`relative_geopotential_thickness_on_hybrid_levels` for details.
 
-    vertical_axis : int, optional
+    vertical_dim : int, optional
         Axis corresponding to the vertical coordinate (hybrid levels) in the output arrays.
         Default is 0 (first axis).
 
@@ -575,7 +575,7 @@ def pressure_on_hybrid_levels(
     -------
     array-like or tuple of array-like
         See the ``output`` parameter for details. The axis corresponding to the vertical
-        coordinate (hybrid levels) in the output arrays is defined by the ``vertical_axis``
+        coordinate (hybrid levels) in the output arrays is defined by the ``vertical_dim``
         parameter.
 
     Notes
@@ -735,9 +735,9 @@ def pressure_on_hybrid_levels(
                 delta = delta[out_full_idx, ...]
             res.append(delta)
 
-    if vertical_axis != 0 and res[0].ndim > 1:
+    if vertical_dim != 0 and res[0].ndim > 1:
         # move the vertical axis to the required position
-        res = [xp.moveaxis(r, 0, vertical_axis) for r in res]
+        res = [xp.moveaxis(r, 0, vertical_dim) for r in res]
 
     if len(res) == 1:
         return res[0]
@@ -760,7 +760,7 @@ def _compute_relative_geopotential_thickness_on_hybrid_levels(
     ----------
     t : array-like
         Temperature on hybrid full-levels (K). The axis corresponding to the vertical
-        coordinate (hybrid levels) is defined by the ``vertical_axis`` parameter.
+        coordinate (hybrid levels) is defined by the ``vertical_dim`` parameter.
         The levels must be in ascending order with respect the model level number. Not
         all the levels must be present, but a contiguous level range including the bottom-most
         level must be used. E.g. if the vertical coordinate system has 137 model levels using
@@ -775,7 +775,7 @@ def _compute_relative_geopotential_thickness_on_hybrid_levels(
     delta : array-like
         Delta term of pressure calculations computed using :func:`pressure_on_hybrid_levels`.
         Must have the same shape, level range and order as ``t``.
-    vertical_axis : int, optional
+    vertical_dim : int, optional
         Axis corresponding to the vertical coordinate (hybrid levels) in the input arrays
         and also in the output array. Default is 0 (first axis).
 
@@ -784,7 +784,7 @@ def _compute_relative_geopotential_thickness_on_hybrid_levels(
     array-like
         Geopotential thickness (m2/s2) between the surface and hybrid full-levels.
         The axis corresponding to the vertical coordinate (hybrid levels) is defined
-        by the ``vertical_axis`` parameter.
+        by the ``vertical_dim`` parameter.
 
     Notes
     -----
@@ -824,7 +824,7 @@ def relative_geopotential_thickness_on_hybrid_levels_from_alpha_delta(
     q: ArrayLike,
     alpha: ArrayLike,
     delta: ArrayLike,
-    vertical_axis=0,
+    vertical_dim=0,
 ) -> ArrayLike:
     """Compute the geopotential thickness between the surface and hybrid full-levels (IFS model levels).
 
@@ -834,7 +834,7 @@ def relative_geopotential_thickness_on_hybrid_levels_from_alpha_delta(
     ----------
     t : array-like
         Temperature on hybrid full-levels (K). The axis corresponding to the vertical
-        coordinate (hybrid levels) is defined by the ``vertical_axis`` parameter.
+        coordinate (hybrid levels) is defined by the ``vertical_dim`` parameter.
         The levels must be in ascending order with respect the model level number. Not
         all the levels must be present, but a contiguous level range including the bottom-most
         level must be used. E.g. if the vertical coordinate system has 137 model levels using
@@ -849,7 +849,7 @@ def relative_geopotential_thickness_on_hybrid_levels_from_alpha_delta(
     delta : array-like
         Delta term of pressure calculations computed using :func:`pressure_on_hybrid_levels`.
         Must have the same shape, level range and order as ``t``.
-    vertical_axis : int, optional
+    vertical_dim : int, optional
         Axis corresponding to the vertical coordinate (hybrid levels) in the input arrays
         and also in the output array. Default is 0 (first axis).
 
@@ -858,7 +858,7 @@ def relative_geopotential_thickness_on_hybrid_levels_from_alpha_delta(
     array-like
         Geopotential thickness (m2/s2) between the surface and hybrid full-levels.
         The axis corresponding to the vertical coordinate (hybrid levels) is defined
-        by the ``vertical_axis`` parameter.
+        by the ``vertical_dim`` parameter.
 
     Notes
     -----
@@ -882,18 +882,18 @@ def relative_geopotential_thickness_on_hybrid_levels_from_alpha_delta(
     t = xp.asarray(t)
     q = xp.asarray(q)
 
-    if vertical_axis != 0:
+    if vertical_dim != 0:
         # move the vertical axis to the first position
-        alpha = xp.moveaxis(alpha, vertical_axis, 0)
-        delta = xp.moveaxis(delta, vertical_axis, 0)
-        t = xp.moveaxis(t, vertical_axis, 0)
-        q = xp.moveaxis(q, vertical_axis, 0)
+        alpha = xp.moveaxis(alpha, vertical_dim, 0)
+        delta = xp.moveaxis(delta, vertical_dim, 0)
+        t = xp.moveaxis(t, vertical_dim, 0)
+        q = xp.moveaxis(q, vertical_dim, 0)
 
     dphi = _compute_relative_geopotential_thickness_on_hybrid_levels(t, q, alpha, delta, xp)
 
-    if vertical_axis != 0:
+    if vertical_dim != 0:
         # move the vertical axis back to its original position
-        dphi = xp.moveaxis(dphi, 0, vertical_axis)
+        dphi = xp.moveaxis(dphi, 0, vertical_dim)
 
     return dphi
 
@@ -905,7 +905,7 @@ def relative_geopotential_thickness_on_hybrid_levels(
     B: ArrayLike,
     sp: ArrayLike,
     alpha_top="ifs",
-    vertical_axis=0,
+    vertical_dim=0,
 ) -> ArrayLike:
     """Compute the geopotential thickness between the surface and hybrid full-levels (IFS model levels).
 
@@ -915,7 +915,7 @@ def relative_geopotential_thickness_on_hybrid_levels(
     ----------
     t : array-like
         Temperature on hybrid full-levels (K). The axis corresponding to the vertical
-        coordinate (hybrid levels) is defined by the ``vertical_axis`` parameter.
+        coordinate (hybrid levels) is defined by the ``vertical_dim`` parameter.
         The levels must be in ascending order with respect the model level number. Not
         all the levels must be present, but a contiguous level range including the bottom-most
         level must be used. E.g. if the vertical coordinate system has 137 model levels using
@@ -936,7 +936,7 @@ def relative_geopotential_thickness_on_hybrid_levels(
         Option to initialise the alpha parameters (for details see below) on the top of the
         model atmosphere (first half-level in the vertical coordinate system). See
         :func:`pressure_on_hybrid_levels` for details.
-    vertical_axis : int, optional
+    vertical_dim : int, optional
         Axis corresponding to the vertical coordinate (model levels) in the input ``t``
         and ``q`` arrays and also in the output array. Default is 0 (first axis).
 
@@ -945,7 +945,7 @@ def relative_geopotential_thickness_on_hybrid_levels(
     array-like
         Geopotential thickness (m2/s2) between the surface and hybrid full-levels. The
         axis corresponding to the vertical coordinate (hybrid levels) is defined by the
-        ``vertical_axis`` parameter.
+        ``vertical_dim`` parameter.
 
     Notes
     -----
@@ -974,29 +974,29 @@ def relative_geopotential_thickness_on_hybrid_levels(
     t = xp.asarray(t)
     q = xp.asarray(q)
 
-    levels = _hybrid_subset(t, A, B, vertical_axis)
+    levels = _hybrid_subset(t, A, B, vertical_dim)
 
     alpha, delta = pressure_on_hybrid_levels(
         A, B, sp, alpha_top=alpha_top, levels=levels, output=("alpha", "delta")
     )
 
     # return relative_geopotential_thickness_on_hybrid_levels_from_alpha_delta(
-    #     t, q, alpha, delta, vertical_axis=vertical_axis
+    #     t, q, alpha, delta, vertical_dim=vertical_dim
     # )
 
     # move the vertical axis to the first position
-    if vertical_axis != 0:
+    if vertical_dim != 0:
         # move the vertical axis to the first position
-        alpha = xp.moveaxis(alpha, vertical_axis, 0)
-        delta = xp.moveaxis(delta, vertical_axis, 0)
-        t = xp.moveaxis(t, vertical_axis, 0)
-        q = xp.moveaxis(q, vertical_axis, 0)
+        alpha = xp.moveaxis(alpha, vertical_dim, 0)
+        delta = xp.moveaxis(delta, vertical_dim, 0)
+        t = xp.moveaxis(t, vertical_dim, 0)
+        q = xp.moveaxis(q, vertical_dim, 0)
 
     dphi = _compute_relative_geopotential_thickness_on_hybrid_levels(t, q, alpha, delta, xp)
 
     # move the vertical axis back to its original position
-    if vertical_axis != 0:
-        dphi = xp.moveaxis(dphi, 0, vertical_axis)
+    if vertical_dim != 0:
+        dphi = xp.moveaxis(dphi, 0, vertical_dim)
 
     return dphi
 
@@ -1009,7 +1009,7 @@ def geopotential_on_hybrid_levels(
     B: ArrayLike,
     sp: ArrayLike,
     alpha_top="ifs",
-    vertical_axis=0,
+    vertical_dim=0,
 ):
     """Compute the geopotential on hybrid (IFS model) full-levels.
 
@@ -1019,7 +1019,7 @@ def geopotential_on_hybrid_levels(
     ----------
     t : array-like
         Temperature on hybrid full-levels (K). The axis corresponding to the vertical
-        coordinate (hybrid levels) is defined by the ``vertical_axis`` parameter.
+        coordinate (hybrid levels) is defined by the ``vertical_dim`` parameter.
         The levels must be in ascending order with respect the model level number. Not
         all the levels must be present, but a contiguous level range including the bottom-most
         level must be used. E.g. if the vertical coordinate system has 137 model levels using
@@ -1041,7 +1041,7 @@ def geopotential_on_hybrid_levels(
         Option to initialise the alpha parameters (for details see below) on the top of the
         model atmosphere (first half-level in the vertical coordinate system). See
         :func:`pressure_on_hybrid_levels` for details.
-    vertical_axis : int, optional
+    vertical_dim : int, optional
         Axis corresponding to the vertical coordinate (model levels) in the input ``t``
         and ``q`` arrays and also in the output array. Default is 0 (first axis).
 
@@ -1050,7 +1050,7 @@ def geopotential_on_hybrid_levels(
     -------
     array-like
         Geopotential (m2/s2) on hybrid full-levels. The axis corresponding to the vertical
-        coordinate (hybrid levels) is defined by the ``vertical_axis`` parameter.
+        coordinate (hybrid levels) is defined by the ``vertical_dim`` parameter.
 
     Notes
     -----
@@ -1069,7 +1069,7 @@ def geopotential_on_hybrid_levels(
 
     """
     z = relative_geopotential_thickness_on_hybrid_levels(
-        t, q, A, B, sp, vertical_axis=vertical_axis, alpha_top=alpha_top
+        t, q, A, B, sp, vertical_dim=vertical_dim, alpha_top=alpha_top
     )
     xp = array_namespace(z, zs)
     zs = xp.asarray(zs)
@@ -1086,7 +1086,7 @@ def height_on_hybrid_levels(
     alpha_top="ifs",
     h_type: str = "geometric",
     h_reference: str = "ground",
-    vertical_axis=0,
+    vertical_dim=0,
 ):
     """Compute the height on hybrid (IFS model) full-levels.
 
@@ -1096,7 +1096,7 @@ def height_on_hybrid_levels(
     ----------
     t : array-like
         Temperature on hybrid full-levels (K). The axis corresponding to the vertical
-        coordinate (hybrid levels) is defined by the ``vertical_axis`` parameter.
+        coordinate (hybrid levels) is defined by the ``vertical_dim`` parameter.
         The levels must be in ascending order with respect the model level number. Not
         all the levels must be present, but a contiguous level range including the bottom-most
         level must be used. E.g. if the vertical coordinate system has 137 model levels using
@@ -1135,7 +1135,7 @@ def height_on_hybrid_levels(
         - "ground": height with respect to the ground/surface level
         - "sea": height with respect to the sea level
 
-    vertical_axis : int, optional
+    vertical_dim : int, optional
         Axis corresponding to the vertical coordinate (hybrid full-levels) in the input
         arrays and also in the output array. Default is 0 (first axis).
 
@@ -1145,7 +1145,7 @@ def height_on_hybrid_levels(
         Height (m) of hybrid full-levels with
         respect to ``h_reference``. The type of height is defined by ``h_type``
         ("geometric" or "geopotential"). The axis corresponding to the vertical
-        coordinate (hybrid levels) is defined by the ``vertical_axis`` parameter.
+        coordinate (hybrid levels) is defined by the ``vertical_dim`` parameter.
 
     Notes
     -----
@@ -1171,7 +1171,7 @@ def height_on_hybrid_levels(
         raise ValueError(f"Unknown '{h_reference=}'. Use 'sea' or 'ground'.")
 
     z_thickness = relative_geopotential_thickness_on_hybrid_levels(
-        t, q, A, B, sp, alpha_top=alpha_top, vertical_axis=vertical_axis
+        t, q, A, B, sp, alpha_top=alpha_top, vertical_dim=vertical_dim
     )
 
     xp = array_namespace(z_thickness)
@@ -1195,9 +1195,9 @@ def height_on_hybrid_levels(
     return h
 
 
-def _hybrid_subset(data, A, B, vertical_axis=0):
+def _hybrid_subset(data, A, B, vertical_dim=0):
     """Helper function to determine the subset of hybrid levels corresponding to the data levels."""
-    nlev_t = data.shape[vertical_axis]
+    nlev_t = data.shape[vertical_dim]
     nlev = A.shape[0] - 1  # number of model full-levels
     levels = None
     if nlev_t != nlev:
@@ -1222,7 +1222,7 @@ def interpolate_hybrid_to_pressure_levels(
     aux_bottom_p=None,
     aux_top_data=None,
     aux_top_p=None,
-    vertical_axis=0,
+    vertical_dim=0,
 ):
     """Interpolate data from hybrid full-levels (IFS model levels) to pressure levels.
 
@@ -1232,7 +1232,7 @@ def interpolate_hybrid_to_pressure_levels(
     ----------
     data : array-like
         Data to be interpolated. The axis corresponding to the vertical
-        coordinate (hybrid levels) is defined by the ``vertical_axis`` parameter.
+        coordinate (hybrid levels) is defined by the ``vertical_dim`` parameter.
         Must have at least two levels. Levels must be ordered in ascending order
         with respect to the model level number. By convention, model level numbering
         starts at 1 at the top of the atmosphere and increases towards the surface.
@@ -1242,7 +1242,7 @@ def interpolate_hybrid_to_pressure_levels(
     target_p : array-like
         Target pressure levels (Pa) to which ``data`` will be interpolated. It can be
         either a scalar or a 1D array of pressure levels. Alternatively, it can be a
-        multidimensional array with a vertical axis defined by ``vertical_axis``. In this
+        multidimensional array with a vertical axis defined by ``vertical_dim``. In this
         case the other axes/dimensions must match those of ``data``.
     A : array-like
         A-coefficients defining the hybrid levels. Must contain all the half-levels
@@ -1280,7 +1280,7 @@ def interpolate_hybrid_to_pressure_levels(
     aux_top_p : array-like, optional
         Pressures (Pa) of ``aux_top_data``. Can be a scalar or must have the same
         shape as a single level of ``data``.
-    vertical_axis : int, optional
+    vertical_dim : int, optional
         Axis corresponding to the vertical coordinate (hybrid full-levels) in the input
         arrays and also in the output array. Default is 0 (first axis).
 
@@ -1290,7 +1290,7 @@ def interpolate_hybrid_to_pressure_levels(
     array-like
         Data interpolated to the target levels. The shape depends on the shape of ``target_p``.
         The axis corresponding to the vertical coordinate (hybrid levels) is defined by
-        the ``vertical_axis`` parameter. When interpolation is not possible for a given target
+        the ``vertical_dim`` parameter. When interpolation is not possible for a given target
         pressure level (e.g., when the target pressure is outside the available pressure range),
         the corresponding output values are set to nan.
 
@@ -1317,7 +1317,7 @@ def interpolate_hybrid_to_pressure_levels(
     B = xp.asarray(B)
     sp = xp.asarray(sp)
 
-    levels = _hybrid_subset(data, A, B, vertical_axis)
+    levels = _hybrid_subset(data, A, B, vertical_dim)
 
     p = pressure_on_hybrid_levels(A, B, sp, alpha_top=alpha_top, levels=levels, output="full")
     return interpolate_monotonic(
@@ -1329,7 +1329,7 @@ def interpolate_hybrid_to_pressure_levels(
         aux_min_level_data=aux_top_data,
         aux_max_level_coord=aux_bottom_p,
         aux_max_level_data=aux_bottom_data,
-        vertical_dim=vertical_axis,
+        vertical_dim=vertical_dim,
     )
 
 
@@ -1350,7 +1350,7 @@ def interpolate_hybrid_to_height_levels(
     aux_bottom_h=None,
     aux_top_data=None,
     aux_top_h=None,
-    vertical_axis=0,
+    vertical_dim=0,
 ):
     """Interpolate data from hybrid full-levels (IFS model levels) to height levels.
 
@@ -1360,7 +1360,7 @@ def interpolate_hybrid_to_height_levels(
     ----------
     data : array-like
         Data to be interpolated. The axis corresponding to the vertical
-        coordinate (hybrid levels) is defined by the ``vertical_axis`` parameter.
+        coordinate (hybrid levels) is defined by the ``vertical_dim`` parameter.
         Must have at least two levels. Levels must be ordered in ascending order
         with respect to the model level number.  By convention, model level numbering
         starts at 1 at the top of the atmosphere and increases towards the surface.  Not
@@ -1371,7 +1371,7 @@ def interpolate_hybrid_to_height_levels(
     target_h : array-like
         Target height levels (m) to which ``data`` will be interpolated. It can be
         either a scalar or a 1D array of height levels. Alternatively, it can be a
-        multidimensional array with a vertical axis defined by `vertical_axis`. In this case
+        multidimensional array with a vertical axis defined by `vertical_dim`. In this case
         the other axes/dimensions must match those of ``data``. The type of the height and
         the reference level are defined by ``h_type`` and ``h_reference``.
     t : array-like
@@ -1436,7 +1436,7 @@ def interpolate_hybrid_to_height_levels(
         Heights (m) of ``aux_top_data``. Can be a scalar or must have the same
         shape as a single level of ``data``.  The type of the height and
         the reference level are defined by ``h_type`` and ``h_reference``.
-    vertical_axis : int, optional
+    vertical_dim : int, optional
         Axis corresponding to the vertical coordinate (hybrid full-levels) in the input
         arrays and also in the output array. Default is 0 (first axis).
 
@@ -1446,7 +1446,7 @@ def interpolate_hybrid_to_height_levels(
     array-like
         Data interpolated to the target height levels. The shape depends on the shape
         of ``target_h``. The axis corresponding to the vertical coordinate (hybrid levels)
-        is defined by the ``vertical_axis`` parameter. When interpolation is not possible
+        is defined by the ``vertical_dim`` parameter. When interpolation is not possible
         for a given target height level (e.g., when the target height is outside the
         available height range), the corresponding output values are set to nan.
 
@@ -1477,7 +1477,7 @@ def interpolate_hybrid_to_height_levels(
         alpha_top=alpha_top,
         h_type=h_type,
         h_reference=h_reference,
-        vertical_axis=vertical_axis,
+        vertical_dim=vertical_dim,
     )
 
     return interpolate_monotonic(
@@ -1489,7 +1489,7 @@ def interpolate_hybrid_to_height_levels(
         aux_min_level_coord=aux_bottom_h,
         aux_max_level_coord=aux_top_h,
         aux_max_level_data=aux_top_data,
-        vertical_dim=vertical_axis,
+        vertical_dim=vertical_dim,
     )
 
 
@@ -1505,7 +1505,7 @@ def interpolate_pressure_to_height_levels(
     aux_bottom_h=None,
     aux_top_data=None,
     aux_top_h=None,
-    vertical_axis: int = 0,
+    vertical_dim: int = 0,
 ):
     """Interpolate data from pressure levels to height levels.
 
@@ -1515,13 +1515,13 @@ def interpolate_pressure_to_height_levels(
     ----------
     data : array-like
         Data to be interpolated. The axis corresponding to the vertical
-        coordinate (pressure levels) is defined by the ``vertical_axis`` parameter.
+        coordinate (pressure levels) is defined by the ``vertical_dim`` parameter.
         Must have at least two levels. Levels must be ordered in ascending or
         descending order with respect to pressure (i.e. monotonic).
     target_h : array-like
         Target height levels (m) to which ``data`` will be interpolated. It can be
         either a scalar or a 1D array of height levels. Alternatively, it can be a
-        multidimensional array with a vertical axis defined by `vertical_axis`. In this case
+        multidimensional array with a vertical axis defined by `vertical_dim`. In this case
         the other axes/dimensions must match those of ``data``. The type of the height and
         the reference level are defined by ``h_type`` and ``h_reference``.
     z : array-like
@@ -1566,7 +1566,7 @@ def interpolate_pressure_to_height_levels(
         Heights (m) of ``aux_top_data``. Can be a scalar or must have the same
         shape as a single level of ``data``. The type of the height and
         the reference level are defined by ``h_type`` and ``h_reference``.
-    vertical_axis : int, optional
+    vertical_dim : int, optional
         Axis corresponding to the vertical coordinate (hybrid full-levels) in the input
         arrays and also in the output array. Default is 0 (first axis).
 
@@ -1576,7 +1576,7 @@ def interpolate_pressure_to_height_levels(
     array-like
         Data interpolated to the target height levels. The shape depends on the shape
         of ``target_h``. The axis corresponding to the vertical coordinate (height levels)
-        is defined by the ``vertical_axis`` parameter. When interpolation is not possible
+        is defined by the ``vertical_dim`` parameter. When interpolation is not possible
         for a given target height level (e.g., when the target height is outside the
         available height range), the corresponding output values are set to nan.
 
@@ -1616,7 +1616,7 @@ def interpolate_pressure_to_height_levels(
         aux_min_level_coord=aux_bottom_h,
         aux_max_level_coord=aux_top_h,
         aux_max_level_data=aux_top_data,
-        vertical_dim=vertical_axis,
+        vertical_dim=vertical_dim,
     )
 
 
@@ -1639,7 +1639,7 @@ def interpolate_monotonic(
     ----------
     data : array-like
         Data to be interpolated. The axis corresponding to the vertical
-        coordinate is defined by the ``vertical_axis`` parameter.
+        coordinate is defined by the ``vertical_dim`` parameter.
         Must have at least two levels.
     coord : array-like
         Vertical coordinates related to ``data``. Either must have the same
@@ -1649,7 +1649,7 @@ def interpolate_monotonic(
     target_coord : array-like
         Target coordinate levels to which ``data`` will be interpolated. It can be
         either a scalar or a 1D array of coordinate levels. Alternatively, it can be a
-        multidimensional array with a vertical axis defined by `vertical_axis`. In this case
+        multidimensional array with a vertical axis defined by `vertical_dim`. In this case
         the other axes/dimensions must match those of ``data``. Must be the same type
         of coordinate as ``coord``.
     interpolation  : str, optional
@@ -1675,7 +1675,7 @@ def interpolate_monotonic(
         Coordinates of ``aux_max_level_data``. Can be a scalar or must have the
         same shape as a single level of ``data`` or ``coord``. Must be the same type
         of coordinate as ``coord``.
-    vertical_axis : int, optional
+    vertical_dim : int, optional
         Axis corresponding to the vertical coordinate in the input arrays and also in the
         output array. Default is 0 (first axis).
 
@@ -1685,7 +1685,7 @@ def interpolate_monotonic(
     array-like
         Data interpolated to the target levels. The shape depends on the shape of ``target_coord``.
         The axis corresponding to the vertical coordinate is defined by
-        the ``vertical_axis`` parameter. When interpolation is not possible for a given target
+        the ``vertical_dim`` parameter. When interpolation is not possible for a given target
         level (e.g., when the target level is outside the available level range),
         the corresponding output values are set to nan.
 
@@ -1722,5 +1722,5 @@ def interpolate_monotonic(
         aux_min_level_coord,
         aux_max_level_data,
         aux_max_level_coord,
-        vertical_axis=vertical_dim,
+        vertical_dim=vertical_dim,
     )

--- a/src/earthkit/meteo/vertical/vertical.py
+++ b/src/earthkit/meteo/vertical/vertical.py
@@ -75,36 +75,36 @@ def pressure_on_hybrid_levels(
     levels=None,
     alpha_top="ifs",
     output="full",
-    vertical_axis=0,
+    vertical_dim=0,
 ):
     return dispatch(pressure_on_hybrid_levels, xarray=False, fieldlist=False, array=True)(
-        A, B, sp, levels=levels, alpha_top=alpha_top, output=output, vertical_axis=vertical_axis
+        A, B, sp, levels=levels, alpha_top=alpha_top, output=output, vertical_dim=vertical_dim
     )
 
 
-def relative_geopotential_thickness_on_hybrid_levels(t, q, A, B, ap, alpha_top="ifs", vertical_axis=0):
+def relative_geopotential_thickness_on_hybrid_levels(t, q, A, B, ap, alpha_top="ifs", vertical_dim=0):
     return dispatch(
         relative_geopotential_thickness_on_hybrid_levels, xarray=False, fieldlist=False, array=True
-    )(t, q, A, B, ap, alpha_top=alpha_top, vertical_axis=vertical_axis)
+    )(t, q, A, B, ap, alpha_top=alpha_top, vertical_dim=vertical_dim)
 
 
-def relative_geopotential_thickness_on_hybrid_levels_from_alpha_delta(t, q, alpha, delta, vertical_axis=0):
+def relative_geopotential_thickness_on_hybrid_levels_from_alpha_delta(t, q, alpha, delta, vertical_dim=0):
     return dispatch(
         relative_geopotential_thickness_on_hybrid_levels_from_alpha_delta,
         xarray=False,
         fieldlist=False,
         array=True,
-    )(t, q, alpha, delta, vertical_axis=vertical_axis)
+    )(t, q, alpha, delta, vertical_dim=vertical_dim)
 
 
-def geopotential_on_hybrid_levels(t, q, zs, A, B, sp, alpha_top="ifs", vertical_axis=0):
+def geopotential_on_hybrid_levels(t, q, zs, A, B, sp, alpha_top="ifs", vertical_dim=0):
     return dispatch(geopotential_on_hybrid_levels, xarray=False, fieldlist=False, array=True)(
-        t, q, zs, A, B, sp, alpha_top=alpha_top, vertical_axis=vertical_axis
+        t, q, zs, A, B, sp, alpha_top=alpha_top, vertical_dim=vertical_dim
     )
 
 
 def height_on_hybrid_levels(
-    t, q, zs, A, B, sp, alpha_top="ifs", h_type="geometrics", h_reference="ground", vertical_axis=0
+    t, q, zs, A, B, sp, alpha_top="ifs", h_type="geometrics", h_reference="ground", vertical_dim=0
 ):
     return dispatch(height_on_hybrid_levels, xarray=False, fieldlist=False, array=True)(
         t,
@@ -116,7 +116,7 @@ def height_on_hybrid_levels(
         alpha_top=alpha_top,
         h_type=h_type,
         h_reference=h_reference,
-        vertical_axis=vertical_axis,
+        vertical_dim=vertical_dim,
     )
 
 
@@ -132,7 +132,7 @@ def interpolate_hybrid_to_pressure_levels(
     aux_bottom_p=None,
     aux_top_data=None,
     aux_top_p=None,
-    vertical_axis=0,
+    vertical_dim=0,
 ):
     return dispatch(interpolate_hybrid_to_pressure_levels, xarray=False, fieldlist=False, array=True)(
         data,
@@ -146,7 +146,7 @@ def interpolate_hybrid_to_pressure_levels(
         aux_bottom_p=aux_bottom_p,
         aux_top_data=aux_top_data,
         aux_top_p=aux_top_p,
-        vertical_axis=vertical_axis,
+        vertical_dim=vertical_dim,
     )
 
 
@@ -167,7 +167,7 @@ def interpolate_hybrid_to_height_levels(
     aux_bottom_h=None,
     aux_top_data=None,
     aux_top_h=None,
-    vertical_axis=0,
+    vertical_dim=0,
 ):
     return dispatch(interpolate_hybrid_to_height_levels, xarray=False, fieldlist=False, array=True)(
         data,
@@ -186,7 +186,7 @@ def interpolate_hybrid_to_height_levels(
         aux_bottom_h=aux_bottom_h,
         aux_top_data=aux_top_data,
         aux_top_h=aux_top_h,
-        vertical_axis=vertical_axis,
+        vertical_dim=vertical_dim,
     )
 
 
@@ -202,7 +202,7 @@ def interpolate_pressure_to_height_levels(
     aux_bottom_h=None,
     aux_top_data=None,
     aux_top_h=None,
-    vertical_axis: int = 0,
+    vertical_dim: int = 0,
 ):
     return dispatch(interpolate_pressure_to_height_levels, xarray=False, fieldlist=False, array=True)(
         data,
@@ -216,5 +216,5 @@ def interpolate_pressure_to_height_levels(
         aux_bottom_h=aux_bottom_h,
         aux_top_data=aux_top_data,
         aux_top_h=aux_top_h,
-        vertical_axis=vertical_axis,
+        vertical_dim=vertical_dim,
     )

--- a/tests/downstream-ci-requirements.txt
+++ b/tests/downstream-ci-requirements.txt
@@ -1,4 +1,4 @@
-earthkit.data
+earthkit-data
 netcdf4
 numpy
 requests

--- a/tests/vertical/test_array_vertical.py
+++ b/tests/vertical/test_array_vertical.py
@@ -235,7 +235,7 @@ def test_pressure_on_hybrid_levels_core(index, xp, device):
 @pytest.mark.parametrize("index", [(slice(None), slice(None)), (slice(None), 0), (slice(None), 1)])
 def test_pressure_on_hybrid_levels_axis(index, xp, device):
     # nondefault vertical axis for output
-    vertical_axis = 1
+    vertical_dim = 1
 
     sp = DATA_HYBRID_CORE.p_surf
     A = DATA_HYBRID_CORE.A
@@ -263,7 +263,7 @@ def test_pressure_on_hybrid_levels_axis(index, xp, device):
         sp,
         alpha_top="ifs",
         output=["full", "half", "delta", "alpha"],
-        vertical_axis=vertical_axis,
+        vertical_dim=vertical_dim,
     )
 
     input_shape = sp.shape
@@ -274,10 +274,10 @@ def test_pressure_on_hybrid_levels_axis(index, xp, device):
     assert alpha.shape == input_shape + (nlev,)
 
     if p_full.ndim > 1:
-        p_full = xp.moveaxis(p_full, vertical_axis, 0)
-        p_half = xp.moveaxis(p_half, vertical_axis, 0)
-        delta = xp.moveaxis(delta, vertical_axis, 0)
-        alpha = xp.moveaxis(alpha, vertical_axis, 0)
+        p_full = xp.moveaxis(p_full, vertical_dim, 0)
+        p_half = xp.moveaxis(p_half, vertical_dim, 0)
+        delta = xp.moveaxis(delta, vertical_dim, 0)
+        alpha = xp.moveaxis(alpha, vertical_dim, 0)
 
     tolerance = Tolerance(
         {


### PR DESCRIPTION
### Description

Use `vertical_dim` instead of `vertical_axis` in array level vertical interface.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 