### PR TITLE
Move celsius_to_kelvin() and kelvin_to_celsius to utils

### DIFF
--- a/src/earthkit/meteo/thermo/array/thermo.py
+++ b/src/earthkit/meteo/thermo/array/thermo.py
@@ -15,6 +15,7 @@ from typing import TypeAlias
 from earthkit.utils.array import array_namespace
 
 from earthkit.meteo import constants
+from earthkit.meteo.utils.convert import celsius_to_kelvin
 
 # import numpy as np
 
@@ -23,40 +24,6 @@ ArrayLike: TypeAlias = Any
 
 # def _valid_number(x):
 #     return x is not None and not np.isnan(x)
-
-
-def celsius_to_kelvin(t: ArrayLike) -> ArrayLike:
-    """Convert temperature values from Celsius to Kelvin.
-
-    Parameters
-    ----------
-    t : number or array-like
-        Temperature in Celsius units
-
-    Returns
-    -------
-    number or array-like
-        Temperature in Kelvin units
-
-    """
-    return t + constants.T_C2K
-
-
-def kelvin_to_celsius(t: ArrayLike) -> ArrayLike:
-    """Convert temperature values from Kelvin to Celsius.
-
-    Parameters
-    ----------
-    t : number or array-like
-        Temperature in Kelvin units
-
-    Returns
-    -------
-    number or array-like
-        Temperature in Celsius units
-
-    """
-    return t - constants.T_C2K
 
 
 def specific_humidity_from_mixing_ratio(w: ArrayLike) -> ArrayLike:

--- a/src/earthkit/meteo/thermo/thermo.py
+++ b/src/earthkit/meteo/thermo/thermo.py
@@ -23,82 +23,82 @@ if TYPE_CHECKING:
 ArrayLike: TypeAlias = Any
 
 
-@overload
-def celsius_to_kelvin(t: "ArrayLike") -> "ArrayLike": ...
+# @overload
+# def _celsius_to_kelvin(t: "ArrayLike") -> "ArrayLike": ...
 
 
-@overload
-def celsius_to_kelvin(t: "xarray.DataArray") -> "xarray.DataArray": ...
+# @overload
+# def _celsius_to_kelvin(t: "xarray.DataArray") -> "xarray.DataArray": ...
 
 
-def celsius_to_kelvin(t: "ArrayLike" | "xarray.DataArray") -> "ArrayLike" | "xarray.DataArray":
-    r"""Convert temperature values from Celsius to Kelvin.
+# def _celsius_to_kelvin(t: "ArrayLike" | "xarray.DataArray") -> "ArrayLike" | "xarray.DataArray":
+#     r"""Convert temperature values from Celsius to Kelvin.
 
-    Parameters
-    ----------
-    t : array-like | xarray.DataArray
-        Temperature in Celsius units
+#     Parameters
+#     ----------
+#     t : array-like | xarray.DataArray
+#         Temperature in Celsius units
 
-    Returns
-    -------
-    array-like | xarray.DataArray
-        Temperature in Kelvin units
-
-
-    Implementations
-    ------------------------
-    :func:`celsius_to_kelvin` calls one of the following implementations depending on
-    the type of the input arguments:
-
-    - :py:meth:`earthkit.meteo.thermo.array.celsius_to_kelvin` for array-like
+#     Returns
+#     -------
+#     array-like | xarray.DataArray
+#         Temperature in Kelvin units
 
 
-    - :py:meth:`earthkit.meteo.thermo.xarray.celsius_to_kelvin`
-      for xarray.DataArray
+#     Implementations
+#     ------------------------
+#     :func:`_celsius_to_kelvin` calls one of the following implementations depending on
+#     the type of the input arguments:
 
-    The function returns an object of the same type as the input arguments.
-    """
-    dispatched = dispatch(celsius_to_kelvin, fieldlist=False, array=True)
-    return dispatched(t)
-
-
-@overload
-def kelvin_to_celsius(t: "ArrayLike") -> "ArrayLike": ...
+#     - :py:meth:`earthkit.meteo.thermo.array._celsius_to_kelvin` for array-like
 
 
-@overload
-def kelvin_to_celsius(t: "xarray.DataArray") -> "xarray.DataArray": ...
+#     - :py:meth:`earthkit.meteo.thermo.xarray._celsius_to_kelvin`
+#       for xarray.DataArray
+
+#     The function returns an object of the same type as the input arguments.
+#     """
+#     dispatched = dispatch(_celsius_to_kelvin, fieldlist=False, array=True)
+#     return dispatched(t)
 
 
-def kelvin_to_celsius(t: "ArrayLike" | "xarray.DataArray") -> "ArrayLike" | "xarray.DataArray":
-    r"""Convert temperature values from Kelvin to Celsius.
-
-    Parameters
-    ----------
-    t : array-like | xarray.DataArray
-        Temperature in Kelvin units
-
-    Returns
-    -------
-    array-like | xarray.DataArray
-        Temperature in Celsius units
+# @overload
+# def _kelvin_to_celsius(t: "ArrayLike") -> "ArrayLike": ...
 
 
-    Implementations
-    ------------------------
-    :func:`kelvin_to_celsius` calls one of the following implementations depending on
-    the type of the input arguments:
-
-    - :py:meth:`earthkit.meteo.thermo.array.kelvin_to_celsius` for array-like
+# @overload
+# def _kelvin_to_celsius(t: "xarray.DataArray") -> "xarray.DataArray": ...
 
 
-    - :py:meth:`earthkit.meteo.thermo.xarray.kelvin_to_celsius`
-      for xarray.DataArray
+# def _kelvin_to_celsius(t: "ArrayLike" | "xarray.DataArray") -> "ArrayLike" | "xarray.DataArray":
+#     r"""Convert temperature values from Kelvin to Celsius.
 
-    The function returns an object of the same type as the input arguments.
-    """
-    dispatched = dispatch(kelvin_to_celsius, fieldlist=False, array=True)
-    return dispatched(t)
+#     Parameters
+#     ----------
+#     t : array-like | xarray.DataArray
+#         Temperature in Kelvin units
+
+#     Returns
+#     -------
+#     array-like | xarray.DataArray
+#         Temperature in Celsius units
+
+
+#     Implementations
+#     ------------------------
+#     :func:`_kelvin_to_celsius` calls one of the following implementations depending on
+#     the type of the input arguments:
+
+#     - :py:meth:`earthkit.meteo.thermo.array._kelvin_to_celsius` for array-like
+
+
+#     - :py:meth:`earthkit.meteo.thermo.xarray._kelvin_to_celsius`
+#       for xarray.DataArray
+
+#     The function returns an object of the same type as the input arguments.
+#     """
+#     dispatched = dispatch(_kelvin_to_celsius, fieldlist=False, array=True)
+#     return dispatched(t)
 
 
 @overload

--- a/src/earthkit/meteo/thermo/xarray/__init__.py
+++ b/src/earthkit/meteo/thermo/xarray/__init__.py
@@ -11,12 +11,12 @@
 Thermo related functions operating on xarray objects.
 """
 
-from .thermo import celsius_to_kelvin
+from .thermo import _celsius_to_kelvin
+from .thermo import _kelvin_to_celsius
 from .thermo import dewpoint_from_relative_humidity
 from .thermo import dewpoint_from_specific_humidity
 from .thermo import ept_from_dewpoint
 from .thermo import ept_from_specific_humidity
-from .thermo import kelvin_to_celsius
 from .thermo import lcl
 from .thermo import lcl_temperature
 from .thermo import mixing_ratio_from_dewpoint
@@ -52,12 +52,12 @@ from .thermo import wet_bulb_temperature_from_dewpoint
 from .thermo import wet_bulb_temperature_from_specific_humidity
 
 __all__ = [
-    "celsius_to_kelvin",
+    "_celsius_to_kelvin",
     "dewpoint_from_relative_humidity",
     "dewpoint_from_specific_humidity",
     "ept_from_dewpoint",
     "ept_from_specific_humidity",
-    "kelvin_to_celsius",
+    "_kelvin_to_celsius",
     "lcl",
     "lcl_temperature",
     "mixing_ratio_from_dewpoint",

--- a/src/earthkit/meteo/thermo/xarray/thermo.py
+++ b/src/earthkit/meteo/thermo/xarray/thermo.py
@@ -16,7 +16,7 @@ from earthkit.meteo.utils.decorators import xarray_ufunc
 from .. import array
 
 
-def celsius_to_kelvin(t: xr.DataArray) -> xr.DataArray:
+def _celsius_to_kelvin(t: xr.DataArray) -> xr.DataArray:
     r"""Convert temperature values from Celsius to Kelvin.
 
     Parameters
@@ -30,7 +30,7 @@ def celsius_to_kelvin(t: xr.DataArray) -> xr.DataArray:
         Temperature in Kelvin units
 
     """
-    return xarray_ufunc(array.celsius_to_kelvin, t).assign_attrs(
+    return xarray_ufunc(array._celsius_to_kelvin, t).assign_attrs(
         {
             "standard_name": "air_temperature",
             "units": "K",
@@ -38,7 +38,7 @@ def celsius_to_kelvin(t: xr.DataArray) -> xr.DataArray:
     )
 
 
-def kelvin_to_celsius(t: xr.DataArray) -> xr.DataArray:
+def _kelvin_to_celsius(t: xr.DataArray) -> xr.DataArray:
     r"""Convert temperature values from Kelvin to Celsius.
 
     Parameters
@@ -52,7 +52,7 @@ def kelvin_to_celsius(t: xr.DataArray) -> xr.DataArray:
         Temperature in Celsius units
 
     """
-    return xarray_ufunc(array.kelvin_to_celsius, t).assign_attrs(
+    return xarray_ufunc(array._kelvin_to_celsius, t).assign_attrs(
         {
             "standard_name": "air_temperature",
             "units": "degC",

--- a/src/earthkit/meteo/utils/convert.py
+++ b/src/earthkit/meteo/utils/convert.py
@@ -1,0 +1,51 @@
+# (C) Copyright 2026 ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+#
+
+from __future__ import annotations
+
+from typing import Any
+from typing import TypeAlias
+
+from earthkit.meteo import constants
+
+ArrayLike: TypeAlias = Any
+
+
+def celsius_to_kelvin(t: ArrayLike) -> ArrayLike:
+    """Convert temperature values from Celsius to Kelvin.
+
+    Parameters
+    ----------
+    t : number or array-like
+        Temperature in Celsius units
+
+    Returns
+    -------
+    number or array-like
+        Temperature in Kelvin units
+
+    """
+    return t + constants.T_C2K
+
+
+def kelvin_to_celsius(t: ArrayLike) -> ArrayLike:
+    """Convert temperature values from Kelvin to Celsius.
+
+    Parameters
+    ----------
+    t : number or array-like
+        Temperature in Kelvin units
+
+    Returns
+    -------
+    number or array-like
+        Temperature in Celsius units
+
+    """
+    return t - constants.T_C2K

--- a/tests/thermo/array/test_thermo.py
+++ b/tests/thermo/array/test_thermo.py
@@ -18,6 +18,7 @@ import pytest
 from earthkit.utils.array.testing import NAMESPACE_DEVICES
 
 from earthkit.meteo import thermo
+from earthkit.meteo.utils import convert
 
 np.set_printoptions(formatter={"float_kind": "{:.10f}".format})
 
@@ -64,17 +65,17 @@ class ThermoInputData:
 
 @pytest.mark.parametrize("xp, device", NAMESPACE_DEVICES)
 @pytest.mark.parametrize("t, v_ref", [([-10, 23.6], [263.15, 296.75])])
-def test_celsius_to_kelvin(xp, device, t, v_ref):
+def test_convert_celsius_to_kelvin(xp, device, t, v_ref):
     t, v_ref = xp.asarray(t, device=device), xp.asarray(v_ref, device=device)
-    tk = thermo.array.celsius_to_kelvin(t)
+    tk = convert.celsius_to_kelvin(t)
     assert xp.allclose(tk, v_ref)
 
 
 @pytest.mark.parametrize("xp, device", NAMESPACE_DEVICES)
 @pytest.mark.parametrize("t, v_ref", [([263.15, 296.75], [-10, 23.6])])
-def test_kelvin_to_celsius(xp, device, t, v_ref):
+def test_convert_kelvin_to_celsius(xp, device, t, v_ref):
     t, v_ref = xp.asarray(t, device=device), xp.asarray(v_ref, device=device)
-    tc = thermo.array.kelvin_to_celsius(t)
+    tc = convert.kelvin_to_celsius(t)
     assert xp.allclose(tc, v_ref)
 
 
@@ -169,7 +170,7 @@ def test_saturation_vapour_pressure_1(xp, device, phase):
     ref_file = "sat_vp.csv"
     # phases = ["mixed", "water", "ice"]
 
-    # o = {"t": thermo.array.celsius_to_kelvin(np.linspace(-40.0, 56.0, 49))}
+    # o = {"t": thermo.array._celsius_to_kelvin(np.linspace(-40.0, 56.0, 49))}
     # for phase in ["mixed", "water", "ice"]:
     #     o[phase] = thermo.array.saturation_vapour_pressure(o["t"], phase=phase)
     # save_test_reference(ref_file, o)
@@ -205,7 +206,7 @@ def test_saturation_vapour_pressure_2(xp, device, t, v_ref, phase):
 def test_saturation_mixing_ratio(phase, xp, device):
     ref_file = "sat_mr.csv"
 
-    # t = thermo.array.celsius_to_kelvin(np.linspace(-40.0, 56.0, 25))
+    # t = thermo.array._celsius_to_kelvin(np.linspace(-40.0, 56.0, 25))
     # p = [1000, 950, 850, 700]
     # t_num = len(t)
     # t = np.repeat(t, repeats=len(p))
@@ -229,7 +230,7 @@ def test_saturation_mixing_ratio(phase, xp, device):
 def test_saturation_specific_humidity(phase, xp, device):
     ref_file = "sat_q.csv"
 
-    # t = thermo.array.celsius_to_kelvin(np.linspace(-40.0, 56.0, 25))
+    # t = thermo.array._celsius_to_kelvin(np.linspace(-40.0, 56.0, 25))
     # p = [1000, 950, 850, 700]
     # t_num = len(t)
     # t = np.repeat(t, repeats=len(p))
@@ -253,7 +254,7 @@ def test_saturation_specific_humidity(phase, xp, device):
 def test_saturation_vapour_pressure_slope(phase, xp, device):
     ref_file = "sat_vp_slope.csv"
 
-    # o = {"t": thermo.array.celsius_to_kelvin(np.linspace(-40.0, 56.0, 49))}
+    # o = {"t": thermo.array._celsius_to_kelvin(np.linspace(-40.0, 56.0, 49))}
     # for phase in ["mixed", "water", "ice"]:
     #     o[phase] = thermo.array.saturation_vapour_pressure_slope(o["t"], phase=phase)
     # save_test_reference(ref_file, o)
@@ -271,7 +272,7 @@ def test_saturation_vapour_pressure_slope(phase, xp, device):
 def test_saturation_mixing_ratio_slope_1(phase, xp, device):
     ref_file = "sat_mr_slope.csv"
 
-    # t = thermo.array.celsius_to_kelvin(np.linspace(-40.0, 56.0, 25))
+    # t = thermo.array._celsius_to_kelvin(np.linspace(-40.0, 56.0, 25))
     # p = [1000, 950, 850, 700]
     # t_num = len(t)
     # t = np.repeat(t, repeats=len(p))
@@ -313,7 +314,7 @@ def test_saturation_specific_humidity_slope_1(phase, xp, device):
     ref_file = "sat_q_slope.csv"
     # phases = ["mixed", "water", "ice"]
 
-    # t = thermo.array.celsius_to_kelvin(np.linspace(-40.0, 56.0, 25))
+    # t = thermo.array._celsius_to_kelvin(np.linspace(-40.0, 56.0, 25))
     # p = [1000, 950, 850, 700]
     # t_num = len(t)
     # t = np.repeat(t, repeats=len(p))
@@ -400,8 +401,8 @@ def test_relative_humidity_from_dewpoint(t, td, v_ref, xp, device):
     t = xp.asarray(t, device=device)
     td = xp.asarray(td, device=device)
     v_ref = xp.asarray(v_ref, device=device)
-    t = thermo.array.celsius_to_kelvin(t)
-    td = thermo.array.celsius_to_kelvin(td)
+    t = convert.celsius_to_kelvin(t)
+    td = convert.celsius_to_kelvin(td)
 
     r = thermo.array.relative_humidity_from_dewpoint(t, td)
     assert xp.allclose(r, v_ref, rtol=1e-05)
@@ -436,7 +437,7 @@ def test_relative_humidity_from_specific_humidity(t, p, q, v_ref, xp, device):
     p = xp.asarray(p, device=device)
     q = xp.asarray(q, device=device)
     v_ref = xp.asarray(v_ref, device=device)
-    t = thermo.array.celsius_to_kelvin(t)
+    t = convert.celsius_to_kelvin(t)
     p = p * 100.0
 
     r = thermo.array.relative_humidity_from_specific_humidity(t, q, p)
@@ -465,7 +466,7 @@ def test_specific_humidity_from_dewpoint(td, p, v_ref, xp, device):
     td = xp.asarray(td, device=device)
     p = xp.asarray(p, device=device)
     v_ref = xp.asarray(v_ref, device=device)
-    td = thermo.array.celsius_to_kelvin(td)
+    td = convert.celsius_to_kelvin(td)
     p = p * 100.0
 
     q = thermo.array.specific_humidity_from_dewpoint(td, p)
@@ -495,7 +496,7 @@ def test_specific_humidity_from_relative_humidity(t, p, r, v_ref, xp, device):
     p = xp.asarray(p, device=device)
     r = xp.asarray(r, device=device)
     v_ref = xp.asarray(v_ref, device=device)
-    t = thermo.array.celsius_to_kelvin(t)
+    t = convert.celsius_to_kelvin(t)
     p = p * 100.0
 
     q = thermo.array.specific_humidity_from_relative_humidity(t, r, p)
@@ -530,8 +531,8 @@ def test_dewpoint_from_relative_humidity(t, r, v_ref, xp, device):
     t = xp.asarray(t, device=device)
     r = xp.asarray(r, device=device)
     v_ref = xp.asarray(v_ref, device=device)
-    t = thermo.array.celsius_to_kelvin(t)
-    v_ref = thermo.array.celsius_to_kelvin(v_ref)
+    t = convert.celsius_to_kelvin(t)
+    v_ref = convert.celsius_to_kelvin(v_ref)
 
     td = thermo.array.dewpoint_from_relative_humidity(t, r)
     assert xp.allclose(td, v_ref, equal_nan=True)
@@ -570,7 +571,7 @@ def test_dewpoint_from_specific_humidity(q, p, v_ref, xp, device):
     q = xp.asarray(q, device=device)
     v_ref = xp.asarray(v_ref, device=device)
     p = p * 100.0
-    v_ref = thermo.array.celsius_to_kelvin(v_ref)
+    v_ref = convert.celsius_to_kelvin(v_ref)
 
     td = thermo.array.dewpoint_from_specific_humidity(q, p)
     assert xp.allclose(td, v_ref, equal_nan=True)
@@ -719,8 +720,8 @@ def test_lcl(t, td, p, t_ref, p_ref, method, xp, device):
     td = xp.asarray(td, device=device)
     t = xp.asarray(t, device=device)
 
-    t = thermo.array.celsius_to_kelvin(t)
-    td = thermo.array.celsius_to_kelvin(td)
+    t = convert.celsius_to_kelvin(t)
+    td = convert.celsius_to_kelvin(td)
 
     t_lcl = thermo.array.lcl_temperature(t, td, method=method)
     assert xp.allclose(t_lcl, t_ref)

--- a/tests/thermo/test_thermo.py
+++ b/tests/thermo/test_thermo.py
@@ -51,8 +51,6 @@ def _ops(impl, celsius, kelvin, t, td, r, q, p):
     ept = impl.ept_from_dewpoint(t, td, p)
 
     return {
-        "celsius_to_kelvin": ((celsius,), {}),
-        "kelvin_to_celsius": ((kelvin,), {}),
         "specific_humidity_from_mixing_ratio": ((w,), {}),
         "mixing_ratio_from_specific_humidity": ((q,), {}),
         "vapour_pressure_from_specific_humidity": ((q, p), {}),
@@ -142,8 +140,6 @@ def backend_case(request):
 @pytest.mark.parametrize(
     "op_name",
     [
-        "celsius_to_kelvin",
-        "kelvin_to_celsius",
         "specific_humidity_from_mixing_ratio",
         "mixing_ratio_from_specific_humidity",
         "vapour_pressure_from_specific_humidity",

--- a/tests/thermo/xarray/test_thermo.py
+++ b/tests/thermo/xarray/test_thermo.py
@@ -62,38 +62,6 @@ def _read_data_file(path):
 
 
 @pytest.mark.parametrize(
-    "t_c",
-    [
-        [-273.15, -40.0, 0.0, 20.0, 100.0, np.nan],
-        0.0,
-    ],
-)
-def test_xr_celsius_to_kelvin(t_c):
-    t_da = _scalar_da(t_c) if np.isscalar(t_c) else _da(t_c)
-    out = thermo.celsius_to_kelvin(t_da)
-    ref = thermo.array.celsius_to_kelvin(_np(t_c))
-    assert np.allclose(out.values, ref, equal_nan=True)
-    if np.isscalar(t_c):
-        assert out.ndim == 0
-
-
-@pytest.mark.parametrize(
-    "t_k",
-    [
-        [0.0, 233.15, 273.15, 293.15, 373.15, np.nan],
-        273.16,
-    ],
-)
-def test_xr_kelvin_to_celsius(t_k):
-    t_da = _scalar_da(t_k) if np.isscalar(t_k) else _da(t_k)
-    out = thermo.kelvin_to_celsius(t_da)
-    ref = thermo.array.kelvin_to_celsius(_np(t_k))
-    assert np.allclose(out.values, ref, equal_nan=True)
-    if np.isscalar(t_k):
-        assert out.ndim == 0
-
-
-@pytest.mark.parametrize(
     "q,p",
     [
         ([0.01], [100000.0]),


### PR DESCRIPTION
### Description

Moved the `kelvin_to_celsius()` and `celsius_to_kelvin()` from `thermo` to `utils.convert`.

Users complained that it did not belong the computations but it was rather a utility method. These methods are still tested.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 