### PR TITLE
FieldList and extended Grid support for regimes

### DIFF
--- a/docs/tutorials/regimes/seven_weather_regimes.ipynb
+++ b/docs/tutorials/regimes/seven_weather_regimes.ipynb
@@ -152,6 +152,25 @@
   },
   {
    "cell_type": "markdown",
+   "id": "69a9f27d",
+   "metadata": {},
+   "source": [
+    "The fields from this repository come in ascending order for the latitude coordinate.\n",
+    "We flip the latitude coordinate to align with the default descending latitude order of an earthkit-geo `Grid`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "e7d087d8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pattern_ds = pattern_ds.isel({\"latitude\": slice(None, None, -1)})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "fdba08fc",
    "metadata": {},
    "source": [
@@ -160,7 +179,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "14ab5c58",
    "metadata": {},
    "outputs": [],
@@ -174,14 +193,6 @@
     "        \"area\": [90, -80, 30, 40],  # 30-90°N, 80°W-40°E\n",
     "    },\n",
     ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "69a9f27d",
-   "metadata": {},
-   "source": [
-    "**Note:** the regime data from this repository uses ascending order for the latitude coordinate. The latitude ordering of fields projected onto these patterns must match."
    ]
   },
   {
@@ -202,7 +213,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "f0b8eeba",
    "metadata": {},
    "outputs": [
@@ -755,11 +766,11 @@
        "Dimensions:  (time: 1, lat: 121, lon: 241)\n",
        "Coordinates:\n",
        "  * time     (time) datetime64[ns] 8B 2025-06-01\n",
-       "  * lat      (lat) float32 484B 30.0 30.5 31.0 31.5 32.0 ... 88.5 89.0 89.5 90.0\n",
+       "  * lat      (lat) float32 484B 90.0 89.5 89.0 88.5 88.0 ... 31.5 31.0 30.5 30.0\n",
        "  * lon      (lon) float32 964B -80.0 -79.5 -79.0 -78.5 ... 38.5 39.0 39.5 40.0\n",
        "    lev      int32 4B 500\n",
        "Data variables:\n",
-       "    Z0       (time, lat, lon) float32 117kB -7.056 -6.082 ... -76.57 -76.57\n",
+       "    Z0       (time, lat, lon) float32 117kB -76.57 -76.57 -76.57 ... 16.52 17.68\n",
        "Attributes:\n",
        "    domxmin:  -180.0\n",
        "    domxmax:  179.5\n",
@@ -770,30 +781,30 @@
        "    lpass:    [240 120  24]\n",
        "    history:  Wed Sep 10 10:11:44 2025: ncks -O -v Z0 Z_N161_20250601_00.nc Z...\n",
        "    source:   Centre source file: /run/media/cgrams/LSDP_2025_1/imk-tnp-chgr/...\n",
-       "    NCO:      netCDF Operators version 5.1.9 (Homepage = http://nco.sf.net, C...</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-226dee4c-b8e5-4741-bd86-2314bd514fa2' class='xr-section-summary-in' type='checkbox' disabled /><label for='section-226dee4c-b8e5-4741-bd86-2314bd514fa2' class='xr-section-summary'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 1</li><li><span class='xr-has-index'>lat</span>: 121</li><li><span class='xr-has-index'>lon</span>: 241</li></ul></div></li><li class='xr-section-item'><input id='section-25cf78bd-a05d-4e22-8b99-d02861e7a082' class='xr-section-summary-in' type='checkbox' checked /><label for='section-25cf78bd-a05d-4e22-8b99-d02861e7a082' class='xr-section-summary' title='Expand/collapse section'>Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2025-06-01</div><input id='attrs-7225009f-31df-4877-bd5f-20417c07fb3b' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-7225009f-31df-4877-bd5f-20417c07fb3b' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-06d07f17-253c-4def-9aa1-aa16231a67d5' class='xr-var-data-in' type='checkbox'><label for='data-06d07f17-253c-4def-9aa1-aa16231a67d5' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([&#x27;2025-06-01T00:00:00.000000000&#x27;], dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>30.0 30.5 31.0 ... 89.0 89.5 90.0</div><input id='attrs-4014d671-d09e-402f-971f-dee70d9684f5' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-4014d671-d09e-402f-971f-dee70d9684f5' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e365037c-ce85-465c-8283-9ddfb18f218b' class='xr-var-data-in' type='checkbox'><label for='data-e365037c-ce85-465c-8283-9ddfb18f218b' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([30. , 30.5, 31. , 31.5, 32. , 32.5, 33. , 33.5, 34. , 34.5, 35. , 35.5,\n",
-       "       36. , 36.5, 37. , 37.5, 38. , 38.5, 39. , 39.5, 40. , 40.5, 41. , 41.5,\n",
-       "       42. , 42.5, 43. , 43.5, 44. , 44.5, 45. , 45.5, 46. , 46.5, 47. , 47.5,\n",
-       "       48. , 48.5, 49. , 49.5, 50. , 50.5, 51. , 51.5, 52. , 52.5, 53. , 53.5,\n",
-       "       54. , 54.5, 55. , 55.5, 56. , 56.5, 57. , 57.5, 58. , 58.5, 59. , 59.5,\n",
-       "       60. , 60.5, 61. , 61.5, 62. , 62.5, 63. , 63.5, 64. , 64.5, 65. , 65.5,\n",
-       "       66. , 66.5, 67. , 67.5, 68. , 68.5, 69. , 69.5, 70. , 70.5, 71. , 71.5,\n",
-       "       72. , 72.5, 73. , 73.5, 74. , 74.5, 75. , 75.5, 76. , 76.5, 77. , 77.5,\n",
-       "       78. , 78.5, 79. , 79.5, 80. , 80.5, 81. , 81.5, 82. , 82.5, 83. , 83.5,\n",
-       "       84. , 84.5, 85. , 85.5, 86. , 86.5, 87. , 87.5, 88. , 88.5, 89. , 89.5,\n",
-       "       90. ], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>-80.0 -79.5 -79.0 ... 39.5 40.0</div><input id='attrs-a87824ae-c88f-475d-af8e-c828cb29128a' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-a87824ae-c88f-475d-af8e-c828cb29128a' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-712584c7-b3d0-4634-8106-4c49ce53b438' class='xr-var-data-in' type='checkbox'><label for='data-712584c7-b3d0-4634-8106-4c49ce53b438' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([-80. , -79.5, -79. , ...,  39. ,  39.5,  40. ],\n",
-       "      shape=(241,), dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>lev</span></div><div class='xr-var-dims'>()</div><div class='xr-var-dtype'>int32</div><div class='xr-var-preview xr-preview'>500</div><input id='attrs-b3b2df7c-14f0-415b-ab23-157fe2e24a94' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-b3b2df7c-14f0-415b-ab23-157fe2e24a94' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-72a2fd49-cfd3-402a-a378-98751a0e4ea3' class='xr-var-data-in' type='checkbox'><label for='data-72a2fd49-cfd3-402a-a378-98751a0e4ea3' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array(500, dtype=int32)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-08b8d7c8-72c8-43c3-ae83-1c73c62c3c1c' class='xr-section-summary-in' type='checkbox' checked /><label for='section-08b8d7c8-72c8-43c3-ae83-1c73c62c3c1c' class='xr-section-summary' title='Expand/collapse section'>Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>Z0</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>-7.056 -6.082 ... -76.57 -76.57</div><input id='attrs-cc85cd84-fc1e-4ab6-b0c1-8765906934c1' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-cc85cd84-fc1e-4ab6-b0c1-8765906934c1' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-294072c8-ee96-4330-b137-137538e22226' class='xr-var-data-in' type='checkbox'><label for='data-294072c8-ee96-4330-b137-137538e22226' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([[[ -7.056082 ,  -6.0819273,  -4.9827185, ...,  15.397836 ,\n",
-       "          16.524744 ,  17.677223 ],\n",
-       "        [ -9.317257 ,  -8.364379 ,  -7.3067837, ...,  13.850015 ,\n",
-       "          15.3339   ,  16.874678 ],\n",
-       "        [-11.542389 , -10.733398 ,  -9.812173 , ...,  11.915309 ,\n",
-       "          13.886759 ,  15.770345 ],\n",
-       "        ...,\n",
-       "        [-78.57062  , -78.80211  , -79.03549  , ..., -92.87785  ,\n",
-       "         -92.71535  , -92.54835  ],\n",
+       "    NCO:      netCDF Operators version 5.1.9 (Homepage = http://nco.sf.net, C...</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-725d1b33-80dc-4207-82af-d406d9c072c1' class='xr-section-summary-in' type='checkbox' disabled /><label for='section-725d1b33-80dc-4207-82af-d406d9c072c1' class='xr-section-summary'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 1</li><li><span class='xr-has-index'>lat</span>: 121</li><li><span class='xr-has-index'>lon</span>: 241</li></ul></div></li><li class='xr-section-item'><input id='section-f9173c33-7c07-42a2-aef5-8dda213ffb3e' class='xr-section-summary-in' type='checkbox' checked /><label for='section-f9173c33-7c07-42a2-aef5-8dda213ffb3e' class='xr-section-summary' title='Expand/collapse section'>Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2025-06-01</div><input id='attrs-0de0e069-2d2f-4c1e-b129-2b00f290af5d' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-0de0e069-2d2f-4c1e-b129-2b00f290af5d' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-15edfd58-50f7-4ee1-b80b-3c1cee9fa18d' class='xr-var-data-in' type='checkbox'><label for='data-15edfd58-50f7-4ee1-b80b-3c1cee9fa18d' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([&#x27;2025-06-01T00:00:00.000000000&#x27;], dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>90.0 89.5 89.0 ... 31.0 30.5 30.0</div><input id='attrs-6d7ff3d1-c3e2-4cd6-8423-53cfb4800c50' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-6d7ff3d1-c3e2-4cd6-8423-53cfb4800c50' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-2e66749d-fcfe-4ab9-8ba7-4c814ccb2812' class='xr-var-data-in' type='checkbox'><label for='data-2e66749d-fcfe-4ab9-8ba7-4c814ccb2812' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([90. , 89.5, 89. , 88.5, 88. , 87.5, 87. , 86.5, 86. , 85.5, 85. , 84.5,\n",
+       "       84. , 83.5, 83. , 82.5, 82. , 81.5, 81. , 80.5, 80. , 79.5, 79. , 78.5,\n",
+       "       78. , 77.5, 77. , 76.5, 76. , 75.5, 75. , 74.5, 74. , 73.5, 73. , 72.5,\n",
+       "       72. , 71.5, 71. , 70.5, 70. , 69.5, 69. , 68.5, 68. , 67.5, 67. , 66.5,\n",
+       "       66. , 65.5, 65. , 64.5, 64. , 63.5, 63. , 62.5, 62. , 61.5, 61. , 60.5,\n",
+       "       60. , 59.5, 59. , 58.5, 58. , 57.5, 57. , 56.5, 56. , 55.5, 55. , 54.5,\n",
+       "       54. , 53.5, 53. , 52.5, 52. , 51.5, 51. , 50.5, 50. , 49.5, 49. , 48.5,\n",
+       "       48. , 47.5, 47. , 46.5, 46. , 45.5, 45. , 44.5, 44. , 43.5, 43. , 42.5,\n",
+       "       42. , 41.5, 41. , 40.5, 40. , 39.5, 39. , 38.5, 38. , 37.5, 37. , 36.5,\n",
+       "       36. , 35.5, 35. , 34.5, 34. , 33.5, 33. , 32.5, 32. , 31.5, 31. , 30.5,\n",
+       "       30. ], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>-80.0 -79.5 -79.0 ... 39.5 40.0</div><input id='attrs-2bae5cb2-6d61-4884-a3bb-24fa048f34de' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-2bae5cb2-6d61-4884-a3bb-24fa048f34de' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-8c3515e3-ef53-409b-84bc-2d1e642a5638' class='xr-var-data-in' type='checkbox'><label for='data-8c3515e3-ef53-409b-84bc-2d1e642a5638' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([-80. , -79.5, -79. , ...,  39. ,  39.5,  40. ],\n",
+       "      shape=(241,), dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>lev</span></div><div class='xr-var-dims'>()</div><div class='xr-var-dtype'>int32</div><div class='xr-var-preview xr-preview'>500</div><input id='attrs-8d4dfd3e-c5ca-4fe5-8b5b-00c8f2eade1e' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-8d4dfd3e-c5ca-4fe5-8b5b-00c8f2eade1e' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-38bb157b-e025-441a-ad0b-dcfa25291e9c' class='xr-var-data-in' type='checkbox'><label for='data-38bb157b-e025-441a-ad0b-dcfa25291e9c' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array(500, dtype=int32)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-624ba9af-285f-43a9-a98a-a78b6f780aad' class='xr-section-summary-in' type='checkbox' checked /><label for='section-624ba9af-285f-43a9-a98a-a78b6f780aad' class='xr-section-summary' title='Expand/collapse section'>Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>Z0</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>-76.57 -76.57 ... 16.52 17.68</div><input id='attrs-27eda5c4-2e80-4650-b578-7580b4bd6f75' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-27eda5c4-2e80-4650-b578-7580b4bd6f75' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-d0f6bd4a-37f3-4c3c-a432-ded18ebf65c2' class='xr-var-data-in' type='checkbox'><label for='data-d0f6bd4a-37f3-4c3c-a432-ded18ebf65c2' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([[[-76.56528  , -76.56528  , -76.56528  , ..., -76.56528  ,\n",
+       "         -76.56528  , -76.56528  ],\n",
        "        [-75.837395 , -75.954475 , -76.071014 , ..., -82.95951  ,\n",
        "         -82.87287  , -82.78812  ],\n",
-       "        [-76.56528  , -76.56528  , -76.56528  , ..., -76.56528  ,\n",
-       "         -76.56528  , -76.56528  ]]], shape=(1, 121, 241), dtype=float32)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-af86e1c8-40db-436c-880d-70b3f01177c6' class='xr-section-summary-in' type='checkbox' /><label for='section-af86e1c8-40db-436c-880d-70b3f01177c6' class='xr-section-summary' title='Expand/collapse section'>Attributes: <span>(10)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>domxmin :</span></dt><dd>-180.0</dd><dt><span>domxmax :</span></dt><dd>179.5</dd><dt><span>domymin :</span></dt><dd>-90.0</dd><dt><span>domymax :</span></dt><dd>90.0</dd><dt><span>date :</span></dt><dd>20250601_00</dd><dt><span>lev :</span></dt><dd>500</dd><dt><span>lpass :</span></dt><dd>[240 120  24]</dd><dt><span>history :</span></dt><dd>Wed Sep 10 10:11:44 2025: ncks -O -v Z0 Z_N161_20250601_00.nc Z0_N161_20250601_00.nc\n",
+       "        [-78.57062  , -78.80211  , -79.03549  , ..., -92.87785  ,\n",
+       "         -92.71535  , -92.54835  ],\n",
+       "        ...,\n",
+       "        [-11.542389 , -10.733398 ,  -9.812173 , ...,  11.915309 ,\n",
+       "          13.886759 ,  15.770345 ],\n",
+       "        [ -9.317257 ,  -8.364379 ,  -7.3067837, ...,  13.850015 ,\n",
+       "          15.3339   ,  16.874678 ],\n",
+       "        [ -7.056082 ,  -6.0819273,  -4.9827185, ...,  15.397836 ,\n",
+       "          16.524744 ,  17.677223 ]]], shape=(1, 121, 241), dtype=float32)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-8477849b-c85f-4b2a-8300-ffc0445ba25b' class='xr-section-summary-in' type='checkbox' /><label for='section-8477849b-c85f-4b2a-8300-ffc0445ba25b' class='xr-section-summary' title='Expand/collapse section'>Attributes: <span>(10)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>domxmin :</span></dt><dd>-180.0</dd><dt><span>domxmax :</span></dt><dd>179.5</dd><dt><span>domymin :</span></dt><dd>-90.0</dd><dt><span>domymax :</span></dt><dd>90.0</dd><dt><span>date :</span></dt><dd>20250601_00</dd><dt><span>lev :</span></dt><dd>500</dd><dt><span>lpass :</span></dt><dd>[240 120  24]</dd><dt><span>history :</span></dt><dd>Wed Sep 10 10:11:44 2025: ncks -O -v Z0 Z_N161_20250601_00.nc Z0_N161_20250601_00.nc\n",
        "Lanczos filtered anomaly with filterwidth 161 timesteps (dt=3h); Z0 is low-pass filtered data 240 h,...; see lpass</dd><dt><span>source :</span></dt><dd>Centre source file: /run/media/cgrams/LSDP_2025_1/imk-tnp-chgr/data/mv0561//ec.era5/dailyano_1979-2019//2025/06/Z20250601_00</dd><dt><span>NCO :</span></dt><dd>netCDF Operators version 5.1.9 (Homepage = http://nco.sf.net, Code = http://github.com/nco/nco, Citation = 10.1016/j.envsoft.2008.03.004)</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
@@ -801,11 +812,11 @@
        "Dimensions:  (time: 1, lat: 121, lon: 241)\n",
        "Coordinates:\n",
        "  * time     (time) datetime64[ns] 8B 2025-06-01\n",
-       "  * lat      (lat) float32 484B 30.0 30.5 31.0 31.5 32.0 ... 88.5 89.0 89.5 90.0\n",
+       "  * lat      (lat) float32 484B 90.0 89.5 89.0 88.5 88.0 ... 31.5 31.0 30.5 30.0\n",
        "  * lon      (lon) float32 964B -80.0 -79.5 -79.0 -78.5 ... 38.5 39.0 39.5 40.0\n",
        "    lev      int32 4B 500\n",
        "Data variables:\n",
-       "    Z0       (time, lat, lon) float32 117kB -7.056 -6.082 ... -76.57 -76.57\n",
+       "    Z0       (time, lat, lon) float32 117kB -76.57 -76.57 -76.57 ... 16.52 17.68\n",
        "Attributes:\n",
        "    domxmin:  -180.0\n",
        "    domxmax:  179.5\n",
@@ -819,7 +830,7 @@
        "    NCO:      netCDF Operators version 5.1.9 (Homepage = http://nco.sf.net, C..."
       ]
      },
-     "execution_count": 7,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -836,27 +847,9 @@
     "# Make time coordinate a dimension so it can be used by the pattern generator\n",
     "ds_field = ds_field.expand_dims(\"time\", axis=0)\n",
     "\n",
-    "# Extract values for the EUR-ATL region\n",
-    "ds_field = ds_field.sel({\"lat\": slice(30, 90), \"lon\": slice(-80, 40)})\n",
+    "# Extract values for the EUR-ATL region that the patterns live on\n",
+    "ds_field = ds_field.sel({\"lat\": pattern_ds[\"latitude\"].values, \"lon\": pattern_ds.coords[\"longitude\"].values})\n",
     "ds_field"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "a491d706",
-   "metadata": {},
-   "source": [
-    "Create area-based weights for the grid points to use in the projection."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "id": "6b0a13c0",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "weights = np.cos(np.deg2rad(ds_field.coords[\"lat\"]))"
    ]
   },
   {
@@ -864,7 +857,8 @@
    "id": "ea43918a",
    "metadata": {},
    "source": [
-    "Project onto the regime patterns, supply the valid date of the field for the modulator function to select the normalisation weight."
+    "Project onto the regime patterns, supply the valid date of the field for the modulator function to select the normalisation weight.\n",
+    "Area-based grid point weights are generated automatically for the projection based on the grid specified with the patterns."
    ]
   },
   {
@@ -874,8 +868,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Map the time coordinate of ds_field to the date argument of pattern_normalisation_weight\n",
-    "projections = regimes.project(ds_field[\"Z0\"], patterns, weights, patterns_coords={\"date\": \"time\"})"
+    "# Map the time coordinate of ds_field to the date argument of pattern_normalisation_weight.\n",
+    "projections = regimes.project(ds_field[\"Z0\"], patterns, patterns_coords={\"date\": \"time\"})"
    ]
   },
   {
@@ -1482,18 +1476,18 @@
        "  stroke-width: 0.8px;\n",
        "}\n",
        "</style><pre class='xr-text-repr-fallback'>&lt;xarray.DataArray &#x27;IWR&#x27; (time: 1, pattern: 7)&gt; Size: 56B\n",
-       "array([[ 0.8218322 ,  1.16918671,  1.04896637, -0.6948882 , -0.57389995,\n",
-       "        -0.93231443, -0.63691209]])\n",
+       "array([[ 0.82183205,  1.16918677,  1.04896647, -0.69488837, -0.57389993,\n",
+       "        -0.93231442, -0.63691223]])\n",
        "Coordinates:\n",
        "  * time     (time) datetime64[ns] 8B 2025-06-01\n",
        "  * pattern  (pattern) &lt;U4 112B &#x27;AT&#x27; &#x27;ZO&#x27; &#x27;ScTr&#x27; &#x27;AR&#x27; &#x27;EuBL&#x27; &#x27;ScBL&#x27; &#x27;GL&#x27;\n",
-       "    lev      int32 4B 500</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-obj-name'>&#x27;IWR&#x27;</div><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 1</li><li><span class='xr-has-index'>pattern</span>: 7</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-cf18ce98-8fb8-4b85-be37-f6298380ac75' class='xr-array-in' type='checkbox' checked><label for='section-cf18ce98-8fb8-4b85-be37-f6298380ac75' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>0.8218 1.169 1.049 -0.6949 -0.5739 -0.9323 -0.6369</span></div><div class='xr-array-data'><pre>array([[ 0.8218322 ,  1.16918671,  1.04896637, -0.6948882 , -0.57389995,\n",
-       "        -0.93231443, -0.63691209]])</pre></div></div></li><li class='xr-section-item'><input id='section-47bbffd6-ac11-492b-8da8-53f49b57fc23' class='xr-section-summary-in' type='checkbox' checked /><label for='section-47bbffd6-ac11-492b-8da8-53f49b57fc23' class='xr-section-summary' title='Expand/collapse section'>Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2025-06-01</div><input id='attrs-b45ca7b8-6e9d-4f84-a0b2-6dceb261c393' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-b45ca7b8-6e9d-4f84-a0b2-6dceb261c393' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-8ba78c42-2686-4cde-8f49-a1b8aec849fc' class='xr-var-data-in' type='checkbox'><label for='data-8ba78c42-2686-4cde-8f49-a1b8aec849fc' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([&#x27;2025-06-01T00:00:00.000000000&#x27;], dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>pattern</span></div><div class='xr-var-dims'>(pattern)</div><div class='xr-var-dtype'>&lt;U4</div><div class='xr-var-preview xr-preview'>&#x27;AT&#x27; &#x27;ZO&#x27; &#x27;ScTr&#x27; ... &#x27;ScBL&#x27; &#x27;GL&#x27;</div><input id='attrs-c99c7eb1-c68a-4043-abb0-86000b96e687' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-c99c7eb1-c68a-4043-abb0-86000b96e687' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-4850ec3f-3f4e-4331-b7e3-41cfb7ba4357' class='xr-var-data-in' type='checkbox'><label for='data-4850ec3f-3f4e-4331-b7e3-41cfb7ba4357' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([&#x27;AT&#x27;, &#x27;ZO&#x27;, &#x27;ScTr&#x27;, &#x27;AR&#x27;, &#x27;EuBL&#x27;, &#x27;ScBL&#x27;, &#x27;GL&#x27;], dtype=&#x27;&lt;U4&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>lev</span></div><div class='xr-var-dims'>()</div><div class='xr-var-dtype'>int32</div><div class='xr-var-preview xr-preview'>500</div><input id='attrs-5b795e78-56c8-445e-ac04-ce7c3260bbf0' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-5b795e78-56c8-445e-ac04-ce7c3260bbf0' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-b61d8f74-a174-4aa9-9345-8bbcdbde97ac' class='xr-var-data-in' type='checkbox'><label for='data-b61d8f74-a174-4aa9-9345-8bbcdbde97ac' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array(500, dtype=int32)</pre></div></li></ul></div></li></ul></div></div>"
+       "    lev      int32 4B 500</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-obj-name'>&#x27;IWR&#x27;</div><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 1</li><li><span class='xr-has-index'>pattern</span>: 7</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-dfe1bda6-8b1f-4479-82a7-7bb5b3abf05c' class='xr-array-in' type='checkbox' checked><label for='section-dfe1bda6-8b1f-4479-82a7-7bb5b3abf05c' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>0.8218 1.169 1.049 -0.6949 -0.5739 -0.9323 -0.6369</span></div><div class='xr-array-data'><pre>array([[ 0.82183205,  1.16918677,  1.04896647, -0.69488837, -0.57389993,\n",
+       "        -0.93231442, -0.63691223]])</pre></div></div></li><li class='xr-section-item'><input id='section-8edbdfc1-e54b-4362-b161-97bdeeffe8cd' class='xr-section-summary-in' type='checkbox' checked /><label for='section-8edbdfc1-e54b-4362-b161-97bdeeffe8cd' class='xr-section-summary' title='Expand/collapse section'>Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2025-06-01</div><input id='attrs-6c2756fd-3a9b-4b7c-b63e-ca4fce365158' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-6c2756fd-3a9b-4b7c-b63e-ca4fce365158' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-c61e3068-198b-4d2e-911c-7e330e795b7b' class='xr-var-data-in' type='checkbox'><label for='data-c61e3068-198b-4d2e-911c-7e330e795b7b' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([&#x27;2025-06-01T00:00:00.000000000&#x27;], dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>pattern</span></div><div class='xr-var-dims'>(pattern)</div><div class='xr-var-dtype'>&lt;U4</div><div class='xr-var-preview xr-preview'>&#x27;AT&#x27; &#x27;ZO&#x27; &#x27;ScTr&#x27; ... &#x27;ScBL&#x27; &#x27;GL&#x27;</div><input id='attrs-6b02e160-78b6-46c0-b387-a7b45af4a61f' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-6b02e160-78b6-46c0-b387-a7b45af4a61f' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-beae370a-76a5-4947-a5f3-0650b08782fc' class='xr-var-data-in' type='checkbox'><label for='data-beae370a-76a5-4947-a5f3-0650b08782fc' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([&#x27;AT&#x27;, &#x27;ZO&#x27;, &#x27;ScTr&#x27;, &#x27;AR&#x27;, &#x27;EuBL&#x27;, &#x27;ScBL&#x27;, &#x27;GL&#x27;], dtype=&#x27;&lt;U4&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>lev</span></div><div class='xr-var-dims'>()</div><div class='xr-var-dtype'>int32</div><div class='xr-var-preview xr-preview'>500</div><input id='attrs-56b10752-f0cf-4565-b89f-f9b8e5520ac3' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-56b10752-f0cf-4565-b89f-f9b8e5520ac3' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-28c87786-5343-4c7e-b60f-7b89b50c0e3b' class='xr-var-data-in' type='checkbox'><label for='data-28c87786-5343-4c7e-b60f-7b89b50c0e3b' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array(500, dtype=int32)</pre></div></li></ul></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.DataArray 'IWR' (time: 1, pattern: 7)> Size: 56B\n",
-       "array([[ 0.8218322 ,  1.16918671,  1.04896637, -0.6948882 , -0.57389995,\n",
-       "        -0.93231443, -0.63691209]])\n",
+       "array([[ 0.82183205,  1.16918677,  1.04896647, -0.69488837, -0.57389993,\n",
+       "        -0.93231442, -0.63691223]])\n",
        "Coordinates:\n",
        "  * time     (time) datetime64[ns] 8B 2025-06-01\n",
        "  * pattern  (pattern) <U4 112B 'AT' 'ZO' 'ScTr' 'AR' 'EuBL' 'ScBL' 'GL'\n",
@@ -1512,7 +1506,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "earthkit-meteo (3.14.4)",
    "language": "python",
    "name": "python3"
   },
@@ -1526,7 +1520,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.1"
+   "version": "3.14.4"
   }
  },
  "nbformat": 4,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ optional-dependencies.test = [
   "astropy",
   "earthkit-data",
   "netcdf4",
+  "pandas",
   "pytest",
   "pytest-cov",
   "requests",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ optional-dependencies.lunar = [
   "astropy"
 ]
 optional-dependencies.regimes = [
-  "earthkit-geo"
+  "earthkit-geo>=1"
 ]
 optional-dependencies.samples = [
   "requests"
@@ -78,7 +78,7 @@ optional-dependencies.stats = [
 optional-dependencies.test = [
   "astropy",
   "earthkit-data",
-  "earthkit-geo",
+  "earthkit-geo>=1",
   "netcdf4",
   "pandas",
   "pytest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ name = "earthkit-meteo"
 readme = "README.md"
 requires-python = ">=3.10"
 optional-dependencies.all = [
-  "earthkit-meteo[samples,scores,stats]"
+  "earthkit-meteo[regimes,samples,scores,stats]"
 ]
 optional-dependencies.dev = [
   "earthkit-meteo[all,docs,test]"
@@ -61,6 +61,9 @@ optional-dependencies.gpu = [
 optional-dependencies.lunar = [
   "astropy"
 ]
+optional-dependencies.regimes = [
+  "earthkit-geo"
+]
 optional-dependencies.samples = [
   "requests"
 ]
@@ -75,6 +78,7 @@ optional-dependencies.stats = [
 optional-dependencies.test = [
   "astropy",
   "earthkit-data",
+  "earthkit-geo",
   "netcdf4",
   "pandas",
   "pytest",

--- a/src/earthkit/meteo/regimes/__init__.py
+++ b/src/earthkit/meteo/regimes/__init__.py
@@ -14,6 +14,8 @@ Weather regimes based on projections onto spatial patterns.
   scheme based on the abstract base class :py:class:`Patterns`.
 - To compute regime indices, use the functions :py:func:`project` and
   :py:func:`regime_index` together with a given pattern collection/generator.
+  These functions dispatch to backend implementations in the ``array``,
+  ``xarray`` and ``fieldlist`` submodules based on the input type.
 
 
 .. note::

--- a/src/earthkit/meteo/regimes/__init__.py
+++ b/src/earthkit/meteo/regimes/__init__.py
@@ -17,15 +17,7 @@ Weather regimes based on projections onto spatial patterns.
   These functions dispatch to backend implementations in the ``array``,
   ``xarray`` and ``fieldlist`` submodules based on the input type.
 
-
-.. note::
-    At the moment, only regular lat-lon grids are supported for the
-    specification of patterns::
-
-        {
-            "grid": [lon_spacing, lat_spacing],
-            "area": [lat0, lon0, lat1, lon1]
-        }
+Requires :py:mod:`earthkit.geo`.
 """
 
 from . import array

--- a/src/earthkit/meteo/regimes/_weights.py
+++ b/src/earthkit/meteo/regimes/_weights.py
@@ -1,0 +1,25 @@
+# (C) Copyright 2026- ECMWF and individual contributors.
+
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation nor
+# does it submit to any jurisdiction.
+
+
+def generate_area_weights(grid, xp):
+    if grid.type == "regular-ll":
+        lats, _ = xp.asarray(grid.to_latlons())
+        return xp.cos(xp.deg2rad(lats)).reshape(grid.shape)
+    raise NotImplementedError("weights generation not available for grid type {grid.type}")
+
+
+def prepare_normalised_weights(weights, patterns):
+    xp = patterns.xp
+    if weights is None:
+        weights = generate_area_weights(patterns.grid, xp)
+    else:
+        weights = xp.asarray(weights)
+    if weights.shape != patterns.shape:
+        raise ValueError(f"shape of weights {weights.shape} must match shape of patterns {patterns.shape}")
+    return weights / weights.sum()

--- a/src/earthkit/meteo/regimes/_weights.py
+++ b/src/earthkit/meteo/regimes/_weights.py
@@ -8,18 +8,33 @@
 
 
 def generate_area_weights(grid, xp):
-    if grid.type == "regular-ll":
+    """Generate area-based weights for the given grid."""
+    if grid.type in {"regular_ll", "regular-ll"}:
         lats, _ = xp.asarray(grid.to_latlons())
         return xp.cos(xp.deg2rad(lats)).reshape(grid.shape)
-    raise NotImplementedError("weights generation not available for grid type {grid.type}")
+    raise NotImplementedError(f"weights generation not available for grid type {grid.type}")
 
 
-def prepare_normalised_weights(weights, patterns):
+def prepare_normalised_weights(patterns, weights=None):
+    """Normalize and verify given weights or generate normalised weights for the patterns.
+
+    Parameters
+    ----------
+    patterns : earthkit.meteo.regimes.Patterns
+        The patterns for which to generate weights for or verify the given
+        weights against.
+    weights : array_like | None
+        The weights to verify and normalise.
+
+    Returns
+    -------
+    array_like
+    """
     xp = patterns.xp
     if weights is None:
         weights = generate_area_weights(patterns.grid, xp)
     else:
         weights = xp.asarray(weights)
     if weights.shape != patterns.shape:
-        raise ValueError(f"shape of weights {weights.shape} must match shape of patterns {patterns.shape}")
+        raise ValueError(f"shape {weights.shape} of weights must match shape {patterns.shape} of patterns {patterns!r}")
     return weights / weights.sum()

--- a/src/earthkit/meteo/regimes/array/index.py
+++ b/src/earthkit/meteo/regimes/array/index.py
@@ -44,7 +44,7 @@ def project(fields, patterns, weights=None, patterns_coords=None):
     fields = array_namespace(fields).expand_dims(fields, -ndim_field - 1)
     if fields.shape[-ndim_field:] != patterns.shape:
         raise ValueError(f"shape of input fields {fields.shape} incompatible with shape of patterns {patterns.shape}")
-    weights = prepare_normalised_weights(weights, patterns)
+    weights = prepare_normalised_weights(patterns, weights=weights)
     sum_axes = tuple(range(-ndim_field, 0, 1))
     return (fields * patterns.patterns(**patterns_coords) * weights).sum(axis=sum_axes)
 

--- a/src/earthkit/meteo/regimes/array/index.py
+++ b/src/earthkit/meteo/regimes/array/index.py
@@ -8,8 +8,10 @@
 
 from earthkit.utils.array import array_namespace
 
+from .._weights import prepare_normalised_weights
 
-def project(fields, patterns, weights, patterns_coords=None):
+
+def project(fields, patterns, weights=None, patterns_coords=None):
     """Project onto the given regime patterns.
 
     Parameters
@@ -19,10 +21,11 @@ def project(fields, patterns, weights, patterns_coords=None):
         dimensions of the input fields.
     patterns : earthkit.meteo.regimes.Patterns
         Patterns to project on.
-    weights : array_like
+    weights : array_like, optional
         Weights for the summation in the projection. Weights are normalised
         before application so the sum of weights over the domain equals 1. Must
-        have shape of the patterns.
+        have shape of the patterns. If no weights are specified, area-based
+        weights are generated from the cosine of latitude of the patterns grid.
     patterns_coords : Mapping[str,Any], optional
         Keyword arguments for the pattern generation. E.g., a sequence of
         dates for date-modulated patterns. Must have the shape of `field`
@@ -38,18 +41,10 @@ def project(fields, patterns, weights, patterns_coords=None):
     if patterns_coords is None:
         patterns_coords = {}
     ndim_field = len(patterns.shape)
+    fields = array_namespace(fields).expand_dims(fields, -ndim_field - 1)
     if fields.shape[-ndim_field:] != patterns.shape:
         raise ValueError(f"shape of input fields {fields.shape} incompatible with shape of patterns {patterns.shape}")
-
-    if weights is None:
-        # TODO generate area-based weights from grid of patterns with earthkit-geo
-        # TODO make weights an optional argument with None default and document
-        raise NotImplementedError("automatic generation of weights")
-    if weights.shape != patterns.shape:
-        raise ValueError(f"shape of weights {weights.shape} must match shape of patterns {patterns.shape}")
-    weights = weights / weights.sum()
-
-    fields = array_namespace(fields).expand_dims(fields, -ndim_field - 1)
+    weights = prepare_normalised_weights(weights, patterns)
     sum_axes = tuple(range(-ndim_field, 0, 1))
     return (fields * patterns.patterns(**patterns_coords) * weights).sum(axis=sum_axes)
 

--- a/src/earthkit/meteo/regimes/array/index.py
+++ b/src/earthkit/meteo/regimes/array/index.py
@@ -28,13 +28,14 @@ def project(fields, patterns, weights=None, patterns_coords=None):
         weights are generated from the cosine of latitude of the patterns grid.
     patterns_coords : Mapping[str,Any], optional
         Keyword arguments for the pattern generation. E.g., a sequence of
-        dates for date-modulated patterns. Must have the shape of `field`
-        without the trailing dimensions onto which the patterns are projected.
+        dates for date-modulated patterns. Each value must have the shape of
+        `fields` without the trailing dimensions onto which the patterns are
+        projected.
 
     Returns
     -------
     array_like
-        Results of the projection. Output fields have same shape as input field
+        Results of the projection. Output fields have same shape as input fields
         except that the dimensions reduced during the projection (i.e., the
         spatial dimensions of the patterns) are replaced by a regime dimension.
     """

--- a/src/earthkit/meteo/regimes/fieldlist/__init__.py
+++ b/src/earthkit/meteo/regimes/fieldlist/__init__.py
@@ -6,7 +6,7 @@
 # granted to it by virtue of its status as an intergovernmental organisation nor
 # does it submit to any jurisdiction.
 
-"""Weather regime functions operating on earthkit.data FieldList objects."""
+"""Weather regime functions operating on earthkit.data Field and FieldList objects."""
 
 from .index import project
 

--- a/src/earthkit/meteo/regimes/fieldlist/__init__.py
+++ b/src/earthkit/meteo/regimes/fieldlist/__init__.py
@@ -1,0 +1,15 @@
+# (C) Copyright 2026- ECMWF and individual contributors.
+
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation nor
+# does it submit to any jurisdiction.
+
+"""Weather regime functions operating on earthkit.data FieldList objects."""
+
+from .index import project
+
+__all__ = [
+    "project",
+]

--- a/src/earthkit/meteo/regimes/fieldlist/index.py
+++ b/src/earthkit/meteo/regimes/fieldlist/index.py
@@ -28,8 +28,7 @@ def project(fields, patterns, weights=None, patterns_coords=None, regrid_to_patt
         have the shape of the patterns. If no weights are specified, area-based
         weights are generated from the patterns grid.
     patterns_coords : Mapping[str,str], optional
-        Mapping of field metadata keys to keyword arguments of the pattern
-        generator.
+        Mapping of pattern-generator keyword arguments to field metadata keys.
     regrid_to_patterns : bool
         Allow regridding of input fields to match the patterns grid. Enabled by
         default.
@@ -53,7 +52,7 @@ def project(fields, patterns, weights=None, patterns_coords=None, regrid_to_patt
                 field = ekg.regrid(field, out_grid=patterns.grid)
             except RuntimeError as e:
                 raise RuntimeError(
-                    f"regrid_to_pattern=True but regridding to pattern grid {patterns.grid!r} failed for {fields!r}"
+                    f"regrid_to_patterns=True but regridding to pattern grid {patterns.grid!r} failed for {fields!r}"
                 ) from e
         values = field.data(keys="value", flatten=False)
         # Extract extra coordinates required for the pattern generation

--- a/src/earthkit/meteo/regimes/fieldlist/index.py
+++ b/src/earthkit/meteo/regimes/fieldlist/index.py
@@ -13,7 +13,7 @@ from .. import array as regimes_array
 from .._weights import prepare_normalised_weights
 
 
-def project(field, patterns, weights=None, **patterns_extra_coords):
+def project(field, patterns, weights=None, patterns_coords=None):
     """Project onto the given patterns.
 
     Parameters
@@ -27,7 +27,7 @@ def project(field, patterns, weights=None, **patterns_extra_coords):
         before application so the sum of weights over the domain equals 1. Must
         have the shape of the patterns. If no weights are specified, area-based
         weights are generated from the cosine of latitude of the patterns grid.
-    **patterns_extra_coords : dict[str, str], optional
+    patterns_coords : Mapping[str,str], optional
         Mapping of field metadata keys to keyword arguments of the pattern
         generator.
 
@@ -37,6 +37,8 @@ def project(field, patterns, weights=None, **patterns_extra_coords):
         The projection(s) for each pattern. One column per pattern, one row
         per field (same order as input fields).
     """
+    if patterns_coords is None:
+        patterns_coords = {}
     weights = prepare_normalised_weights(weights, patterns)
     if not isinstance(field, ekd.FieldList):
         field = field.to_fieldlist()
@@ -45,6 +47,6 @@ def project(field, patterns, weights=None, **patterns_extra_coords):
     for fld in field:
         values = fld.data(keys="value", flatten=False)
         # Extract extra coordinates required for the pattern generation
-        coords = {kwarg: fld.get(coord) for kwarg, coord in patterns_extra_coords.items()}
-        proj.append(regimes_array.project(values, patterns, weights, **coords))
+        coords = {kwarg: fld.get(coord) for kwarg, coord in patterns_coords.items()}
+        proj.append(regimes_array.project(values, patterns, weights, patterns_coords=coords))
     return pd.DataFrame.from_records(proj, columns=patterns.labels)

--- a/src/earthkit/meteo/regimes/fieldlist/index.py
+++ b/src/earthkit/meteo/regimes/fieldlist/index.py
@@ -8,18 +8,17 @@
 
 import earthkit.data as ekd
 import earthkit.geo as ekg
-import pandas as pd
 
 from .. import array as regimes_array
 from .._weights import prepare_normalised_weights
 
 
-def project(field, patterns, weights=None, patterns_coords=None):
+def project(fields, patterns, weights=None, patterns_coords=None, regrid_to_pattern=True):
     """Project onto the given patterns.
 
     Parameters
     ----------
-    field : earthkit.data.FieldList | earthkit.data.Field
+    fields : earthkit.data.FieldList | earthkit.data.Field
         Input fields whose values the patterns are projected onto.
     patterns : earthkit.meteo.regimes.Patterns
         Patterns to project on.
@@ -27,33 +26,37 @@ def project(field, patterns, weights=None, patterns_coords=None):
         Weights for the summation in the projection. Weights are normalised
         before application so the sum of weights over the domain equals 1. Must
         have the shape of the patterns. If no weights are specified, area-based
-        weights are generated from the cosine of latitude of the patterns grid.
+        weights are generated from the patterns grid.
     patterns_coords : Mapping[str,str], optional
         Mapping of field metadata keys to keyword arguments of the pattern
         generator.
+    regrid_to_pattern : bool
+        Allow regridding of input fields to match the pattern grid. Enabled by
+        default.
 
     Returns
     -------
-    pandas.DataFrame
-        The projection(s) for each pattern. One column per pattern, one row
-        per field (same order as input fields).
+    array_like
+        The projection(s) for each pattern. One row per field, one column per
+        pattern. Same order as input fields and pattern labels, respectively.
     """
     if patterns_coords is None:
         patterns_coords = {}
-    weights = prepare_normalised_weights(weights, patterns)
-    if not isinstance(field, ekd.FieldList):
-        field = field.to_fieldlist()
+    weights = prepare_normalised_weights(patterns, weights)
+    if not isinstance(fields, ekd.FieldList):
+        fields = fields.to_fieldlist()
     proj = []
-    for fld in field:
-        # Automatic regridding of fields to match pattern grid (including
-        # cropping to pattern area)
-        if fld.get("geography.grid") != patterns.grid:
+    for field in fields:
+        # Automatic regridding, also covers cropping to pattern area
+        if regrid_to_pattern and field.get("geography.grid") != patterns.grid:
             try:
-                fld = ekg.regrid(fld, out_grid=patterns.grid)
+                field = ekg.regrid(field, out_grid=patterns.grid)
             except RuntimeError as e:
-                raise RuntimeError(f"regridding to pattern grid failed for {fld!r}") from e
-        values = fld.data(keys="value", flatten=False)
+                raise RuntimeError(
+                    f"regrid_to_pattern=True but regridding to pattern grid {patterns.grid!r} failed for {fields!r}"
+                ) from e
+        values = field.data(keys="value", flatten=False)
         # Extract extra coordinates required for the pattern generation
-        coords = {kwarg: fld.get(coord) for kwarg, coord in patterns_coords.items()}
+        coords = {kwarg: field.get(coord) for kwarg, coord in patterns_coords.items()}
         proj.append(regimes_array.project(values, patterns, weights, patterns_coords=coords))
-    return pd.DataFrame.from_records(proj, columns=patterns.labels)
+    return patterns.xp.asarray(proj)

--- a/src/earthkit/meteo/regimes/fieldlist/index.py
+++ b/src/earthkit/meteo/regimes/fieldlist/index.py
@@ -9,8 +9,11 @@
 import earthkit.data as ekd
 import pandas as pd
 
+from .. import array as regimes_array
+from .._weights import prepare_normalised_weights
 
-def project(field, patterns, weights, **patterns_extra_coords):
+
+def project(field, patterns, weights=None, **patterns_extra_coords):
     """Project onto the given patterns.
 
     Parameters
@@ -19,11 +22,12 @@ def project(field, patterns, weights, **patterns_extra_coords):
         Input fields whose values the patterns are projected onto.
     patterns : earthkit.meteo.regimes.Patterns
         Patterns to project on.
-    weights : array_like
+    weights : array_like, optional
         Weights for the summation in the projection. Weights are normalised
         before application so the sum of weights over the domain equals 1. Must
-        have the shape of the patterns.
-    **patterns_extra_coords : dict[str, array_like], optional
+        have the shape of the patterns. If no weights are specified, area-based
+        weights are generated from the cosine of latitude of the patterns grid.
+    **patterns_extra_coords : dict[str, str], optional
         Mapping of field metadata keys to keyword arguments of the pattern
         generator.
 
@@ -33,26 +37,14 @@ def project(field, patterns, weights, **patterns_extra_coords):
         The projection(s) for each pattern. One column per pattern, one row
         per field (same order as input fields).
     """
-    xp = patterns.xp
-
-    if weights is None:
-        # TODO generate area-based weights from grid of patterns with earthkit-geo
-        raise NotImplementedError("automatic generation of weights")
-    weights = xp.asarray(weights)
-    if weights.shape != patterns.shape:
-        raise ValueError(f"shape of weights {weights.shape} must match shape of patterns {patterns.shape}")
-    weights = weights / weights.sum()
-
+    weights = prepare_normalised_weights(weights, patterns)
     if not isinstance(field, ekd.FieldList):
         field = field.to_fieldlist()
     # Project field-by-field to keep peak memory usage down
-    proj = {label: xp.empty(len(field)) for label in patterns.labels}
-    for i, fld in enumerate(field):
-        # TODO verify grid compatibility and regrid with earthkit.geo on mismatch
+    proj = []
+    for fld in field:
         values = fld.data(keys="value", flatten=False)
         # Extract extra coordinates required for the pattern generation
         coords = {kwarg: fld.get(coord) for kwarg, coord in patterns_extra_coords.items()}
-        for label, pattern in patterns.patterns(**coords).items():
-            proj[label][i] = (values * pattern * weights).sum()
-
-    return pd.DataFrame.from_dict(proj)
+        proj.append(regimes_array.project(values, patterns, weights, **coords))
+    return pd.DataFrame.from_records(proj, columns=patterns.labels)

--- a/src/earthkit/meteo/regimes/fieldlist/index.py
+++ b/src/earthkit/meteo/regimes/fieldlist/index.py
@@ -13,7 +13,7 @@ from .. import array as regimes_array
 from .._weights import prepare_normalised_weights
 
 
-def project(fields, patterns, weights=None, patterns_coords=None, regrid_to_pattern=True):
+def project(fields, patterns, weights=None, patterns_coords=None, regrid_to_patterns=True):
     """Project onto the given patterns.
 
     Parameters
@@ -30,8 +30,8 @@ def project(fields, patterns, weights=None, patterns_coords=None, regrid_to_patt
     patterns_coords : Mapping[str,str], optional
         Mapping of field metadata keys to keyword arguments of the pattern
         generator.
-    regrid_to_pattern : bool
-        Allow regridding of input fields to match the pattern grid. Enabled by
+    regrid_to_patterns : bool
+        Allow regridding of input fields to match the patterns grid. Enabled by
         default.
 
     Returns
@@ -48,7 +48,7 @@ def project(fields, patterns, weights=None, patterns_coords=None, regrid_to_patt
     proj = []
     for field in fields:
         # Automatic regridding, also covers cropping to pattern area
-        if regrid_to_pattern and field.get("geography.grid") != patterns.grid:
+        if regrid_to_patterns and field.get("geography.grid") != patterns.grid:
             try:
                 field = ekg.regrid(field, out_grid=patterns.grid)
             except RuntimeError as e:

--- a/src/earthkit/meteo/regimes/fieldlist/index.py
+++ b/src/earthkit/meteo/regimes/fieldlist/index.py
@@ -1,0 +1,58 @@
+# (C) Copyright 2026- ECMWF and individual contributors.
+
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation nor
+# does it submit to any jurisdiction.
+
+import earthkit.data as ekd
+import pandas as pd
+
+
+def project(field, patterns, weights, **patterns_extra_coords):
+    """Project onto the given patterns.
+
+    Parameters
+    ----------
+    field : earthkit.data.FieldList | earthkit.data.Field
+        Input fields whose values the patterns are projected onto.
+    patterns : earthkit.meteo.regimes.Patterns
+        Patterns to project on.
+    weights : array_like
+        Weights for the summation in the projection. Weights are normalised
+        before application so the sum of weights over the domain equals 1. Must
+        have the shape of the patterns.
+    **patterns_extra_coords : dict[str, array_like], optional
+        Mapping of field metadata keys to keyword arguments of the pattern
+        generator.
+
+    Returns
+    -------
+    pandas.DataFrame
+        The projection(s) for each pattern. One column per pattern, one row
+        per field (same order as input fields).
+    """
+    xp = patterns.xp
+
+    if weights is None:
+        # TODO generate area-based weights from grid of patterns with earthkit-geo
+        raise NotImplementedError("automatic generation of weights")
+    weights = xp.asarray(weights)
+    if weights.shape != patterns.shape:
+        raise ValueError(f"shape of weights {weights.shape} must match shape of patterns {patterns.shape}")
+    weights = weights / weights.sum()
+
+    if not isinstance(field, ekd.FieldList):
+        field = field.to_fieldlist()
+    # Project field-by-field to keep peak memory usage down
+    proj = {label: xp.empty(len(field)) for label in patterns.labels}
+    for i, fld in enumerate(field):
+        # TODO verify grid compatibility and regrid with earthkit.geo on mismatch
+        values = fld.data(keys="value", flatten=False)
+        # Extract extra coordinates required for the pattern generation
+        coords = {kwarg: fld.get(coord) for kwarg, coord in patterns_extra_coords.items()}
+        for label, pattern in patterns.patterns(**coords).items():
+            proj[label][i] = (values * pattern * weights).sum()
+
+    return pd.DataFrame.from_dict(proj)

--- a/src/earthkit/meteo/regimes/fieldlist/index.py
+++ b/src/earthkit/meteo/regimes/fieldlist/index.py
@@ -7,6 +7,7 @@
 # does it submit to any jurisdiction.
 
 import earthkit.data as ekd
+import earthkit.geo as ekg
 import pandas as pd
 
 from .. import array as regimes_array
@@ -42,9 +43,15 @@ def project(field, patterns, weights=None, patterns_coords=None):
     weights = prepare_normalised_weights(weights, patterns)
     if not isinstance(field, ekd.FieldList):
         field = field.to_fieldlist()
-    # Project field-by-field to keep peak memory usage down
     proj = []
     for fld in field:
+        # Automatic regridding of fields to match pattern grid (including
+        # cropping to pattern area)
+        if fld.get("geography.grid") != patterns.grid:
+            try:
+                fld = ekg.regrid(fld, out_grid=patterns.grid)
+            except RuntimeError as e:
+                raise RuntimeError(f"regridding to pattern grid failed for {fld!r}") from e
         values = fld.data(keys="value", flatten=False)
         # Extract extra coordinates required for the pattern generation
         coords = {kwarg: fld.get(coord) for kwarg, coord in patterns_coords.items()}

--- a/src/earthkit/meteo/regimes/index.py
+++ b/src/earthkit/meteo/regimes/index.py
@@ -11,7 +11,7 @@ from ..utils.decorators import dispatch
 __all__ = ["project", "regime_index"]
 
 
-def project(fields, patterns, weights, patterns_coords=None):
+def project(fields, patterns, weights=None, patterns_coords=None):
     """Project onto the given patterns.
 
     Parameters
@@ -21,9 +21,11 @@ def project(fields, patterns, weights, patterns_coords=None):
         dimensions of the input fields.
     patterns : earthkit.meteo.regimes.Patterns
         Patterns to project on.
-    weights : xarray.DataArray | array_like
+    weights : xarray.DataArray | array_like, optional
         Weights for the summation in the projection. Weights are normalised
-        before application so the sum of weights over the domain equals 1.
+        before application so the sum of weights over the domain equals 1. If no
+        weights are specified, area-based weights are generated from the cosine
+        of latitude of the patterns grid.
     patterns_coords : Mapping[str,Any] | Sequence[str], optional
         Coordinates for the pattern generation function. Consult the individual
         implementations on the interpretation.

--- a/src/earthkit/meteo/regimes/index.py
+++ b/src/earthkit/meteo/regimes/index.py
@@ -43,7 +43,7 @@ def project(fields, patterns, weights, patterns_coords=None):
 
         The function returns an object of the same type as the input argument.
     """
-    dispatched = dispatch(project, xarray=True, array=True)
+    dispatched = dispatch(project, xarray=True, array=True, fieldlist=True)
     return dispatched(fields, patterns, weights, patterns_coords)
 
 
@@ -78,5 +78,5 @@ def regime_index(projections, mean, std):
 
         (projection - mean) / std
     """
-    dispatched = dispatch(regime_index, xarray=True, array=True)
+    dispatched = dispatch(regime_index, xarray=True, array=True, fieldlist=True)
     return dispatched(projections, mean, std)

--- a/src/earthkit/meteo/regimes/index.py
+++ b/src/earthkit/meteo/regimes/index.py
@@ -24,8 +24,8 @@ def project(fields, patterns, weights=None, patterns_coords=None):
     weights : xarray.DataArray | array_like, optional
         Weights for the summation in the projection. Weights are normalised
         before application so the sum of weights over the domain equals 1. If no
-        weights are specified, area-based weights are generated from the cosine
-        of latitude of the patterns grid.
+        weights are specified, area-based weights are generated from the
+        patterns grid.
     patterns_coords : Mapping[str,Any] | Sequence[str], optional
         Coordinates for the pattern generation function. Consult the individual
         implementations on the interpretation.
@@ -40,10 +40,12 @@ def project(fields, patterns, weights=None, patterns_coords=None):
 
         Depending on the type of argument `fields`, this function calls:
 
-        - :py:func:`earthkit.meteo.regimes.xarray.project` for ``xarray.DataArray``
         - :py:func:`earthkit.meteo.regimes.array.project` for ``array_like``
-
-        The function returns an object of the same type as the input argument.
+          (returns  same type)
+        - :py:func:`earthkit.meteo.regimes.xarray.project` for :py:class:`xarray.DataArray`
+          (returns same type)
+        - :py:func:`earthkit.meteo.regimes.fieldlist.project` for :py:class:`FieldList`
+          or :py:class:`Field` (returns array_like)
     """
     dispatched = dispatch(project, xarray=True, array=True, fieldlist=True)
     return dispatched(fields, patterns, weights, patterns_coords)
@@ -80,5 +82,5 @@ def regime_index(projections, mean, std):
 
         (projection - mean) / std
     """
-    dispatched = dispatch(regime_index, xarray=True, array=True, fieldlist=True)
+    dispatched = dispatch(regime_index, xarray=True, array=True, fieldlist=False)
     return dispatched(projections, mean, std)

--- a/src/earthkit/meteo/regimes/patterns.py
+++ b/src/earthkit/meteo/regimes/patterns.py
@@ -7,9 +7,8 @@
 # does it submit to any jurisdiction.
 
 import abc
-import functools
-import operator
 
+from earthkit.geo.grids import Grid
 from earthkit.utils.array import array_namespace
 
 
@@ -21,7 +20,7 @@ class Patterns(abc.ABC):
     labels : Iterable[str]
         Labels for the patterns. The ordering determines the ordering of all
         outputs.
-    grid : dict
+    grid : earthkit.geo.Grid | dict | str
         Specification of the grid on which the patterns live.
     xp : array_namespace, optional
         Array namespace of the generated patterns.
@@ -29,7 +28,7 @@ class Patterns(abc.ABC):
 
     def __init__(self, labels, *, grid, xp):
         self._labels = tuple(labels)
-        self._grid = grid
+        self._grid = grid if isinstance(grid, Grid) else Grid(grid)
         self._xp = xp
 
     @property
@@ -38,22 +37,19 @@ class Patterns(abc.ABC):
         return self._labels
 
     @property
-    def grid(self) -> dict:
+    def grid(self) -> Grid:
         """The grid on which the patterns live."""
         return self._grid
 
     @property
     def shape(self):
         """Shape of a single pattern."""
-        # TODO placeholder until this functionality is available from earthkit-geo
-        lat0, lon0, lat1, lon1 = self.grid["area"]
-        dlat, dlon = self.grid["grid"]
-        return (int(abs(lat0 - lat1) / dlat) + 1, int(abs(lon0 - lon1) / dlon) + 1)
+        return self._grid.shape
 
     @property
     def size(self) -> int:
         """Number of grid points in a single pattern."""
-        return functools.reduce(operator.mul, self.shape)
+        return self._grid.size()
 
     @property
     def ndim(self) -> int:

--- a/src/earthkit/meteo/regimes/patterns.py
+++ b/src/earthkit/meteo/regimes/patterns.py
@@ -22,7 +22,7 @@ class Patterns(abc.ABC):
         outputs.
     grid : earthkit.geo.Grid | dict | str
         Specification of the grid on which the patterns live.
-    xp : array_namespace, optional
+    xp : array_namespace
         Array namespace of the generated patterns.
     """
 
@@ -81,7 +81,7 @@ class ConstantPatterns(Patterns):
         Labels for the patterns.
     patterns : array_like
         The patterns (one for each label, stacked into a single array).
-    grid : dict
+    grid : earthkit.geo.Grid | dict | str
         Specification of the grid on which the patterns live.
     xp : array_namespace, optional
         The array namespace used for the patterns and their generation. By
@@ -92,7 +92,7 @@ class ConstantPatterns(Patterns):
         if xp is None:
             xp = array_namespace(patterns)
         super().__init__(labels, grid=grid, xp=xp)
-        self._patterns = self._xp.asarray(patterns)
+        self._patterns = self.xp.asarray(patterns)
         if self._patterns.ndim != 1 + len(self.shape):
             raise ValueError("must have exactly one label axis in the patterns")
         if len(self.labels) != self._patterns.shape[0]:
@@ -124,7 +124,7 @@ class ModulatedPatterns(Patterns):
         Scalar function to modulate the base patterns. The parameters required
         to evaluate this function must be provided when projecting as
         `patterns_extra_coords` kwargs.
-    grid : dict
+    grid : earthkit.geo.Grid | dict | str
         Specification of the grid on which the patterns live.
     xp : array_namespace, optional
         The array namespace used for the patterns and their generation. By

--- a/src/earthkit/meteo/regimes/xarray/index.py
+++ b/src/earthkit/meteo/regimes/xarray/index.py
@@ -11,6 +11,8 @@ from collections.abc import Sequence
 import xarray as xr
 from earthkit.utils.array import array_namespace
 
+from .._weights import generate_area_weights
+
 
 def _patterns_xr(patterns, reference_da, patterns_coords, patterns_dim="pattern"):
     """Patterns evaluated for the given coords (if any) as xr.DataArrays.
@@ -59,7 +61,7 @@ def _patterns_xr(patterns, reference_da, patterns_coords, patterns_dim="pattern"
     return xr.DataArray(patterns.patterns(**extra_coords), coords=coords, dims=dims)
 
 
-def project(fields, patterns, weights, patterns_coords=None):
+def project(fields, patterns, weights=None, patterns_coords=None):
     """Project onto the given patterns.
 
     Parameters
@@ -71,7 +73,9 @@ def project(fields, patterns, weights, patterns_coords=None):
         Patterns to project on.
     weights : xarray.DataArray
         Weights for the summation in the projection. Weights are normalised
-        before application so the sum of weights over the domain equals 1.
+        before application so the sum of weights over the domain equals 1. If no
+        weights are specified, area-based weights are generated from the cosine
+        of latitude of the patterns grid.
     patterns_coords : Mapping[str,str] | Sequence[str], optional
         Mapping of coordinate names to keyword arguments of the pattern
         generation function. If a sequence is given, argument and associated
@@ -97,13 +101,13 @@ def project(fields, patterns, weights, patterns_coords=None):
             f"expected {patterns.shape}, got {field_trailing_shape}"
         )
     pattern_dims = fields.dims[-patterns.ndim :]
-
-    # Normalise weights so they sum to one over the pattern domain and
-    # compensate for weights that don't have all pattern dimensions
     if weights is None:
-        raise NotImplementedError("automatic generation of weights")
+        weights = generate_area_weights(patterns.grid, patterns.xp)
+        pattern_coords = {dim: fields.coords[dim] for dim in pattern_dims}
+        weights = xr.DataArray(weights, coords=pattern_coords, dims=pattern_dims)
     if set(weights.dims) - set(pattern_dims):
         raise ValueError("weight must only be specified over pattern dimensions")
+    # Normalise weights and compensate for weights without all pattern dimensions
     weights = weights / weights.sum() * weights.size / patterns.size
 
     patterns_da = _patterns_xr(patterns, fields, patterns_coords)

--- a/src/earthkit/meteo/regimes/xarray/index.py
+++ b/src/earthkit/meteo/regimes/xarray/index.py
@@ -103,6 +103,7 @@ def project(fields, patterns, weights=None, patterns_coords=None):
     pattern_dims = fields.dims[-patterns.ndim :]
     if weights is None:
         weights = generate_area_weights(patterns.grid, patterns.xp)
+        print(weights)
         pattern_coords = {dim: fields.coords[dim] for dim in pattern_dims}
         weights = xr.DataArray(weights, coords=pattern_coords, dims=pattern_dims)
     if set(weights.dims) - set(pattern_dims):

--- a/src/earthkit/meteo/regimes/xarray/index.py
+++ b/src/earthkit/meteo/regimes/xarray/index.py
@@ -77,8 +77,8 @@ def project(fields, patterns, weights=None, patterns_coords=None):
         weights are specified, area-based weights are generated from the cosine
         of latitude of the patterns grid.
     patterns_coords : Mapping[str,str] | Sequence[str], optional
-        Mapping of coordinate names to keyword arguments of the pattern
-        generation function. If a sequence is given, argument and associated
+        Mapping of pattern-generator keyword arguments to coordinate names. If a
+        sequence is given instead of a mapping, argument names and associated
         coordinate names are assumed to be identical. Only coordinates that are
         dimensions of `fields` can be mapped.
 

--- a/src/earthkit/meteo/regimes/xarray/index.py
+++ b/src/earthkit/meteo/regimes/xarray/index.py
@@ -102,8 +102,7 @@ def project(fields, patterns, weights=None, patterns_coords=None):
         )
     pattern_dims = fields.dims[-patterns.ndim :]
     if weights is None:
-        weights = generate_area_weights(patterns.grid, patterns.xp)
-        print(weights)
+        weights = generate_area_weights(patterns.grid, xp=patterns.xp)
         pattern_coords = {dim: fields.coords[dim] for dim in pattern_dims}
         weights = xr.DataArray(weights, coords=pattern_coords, dims=pattern_dims)
     if set(weights.dims) - set(pattern_dims):

--- a/tests/regimes/array/test_index.py
+++ b/tests/regimes/array/test_index.py
@@ -9,21 +9,25 @@
 import numpy as np
 import pytest
 
-from earthkit.meteo.regimes import array
+ekg = pytest.importorskip("earthkit.geo")
+
+from earthkit.meteo.regimes import Patterns, array
 
 
 @pytest.fixture
 def patterns():
-    class MockPatterns:
+    class MockPatterns(Patterns):
         _lat = np.linspace(90.0, 0.0, 91)
         _lon = np.linspace(60.0, -60.0, 121)
         _dipole = np.cos(np.deg2rad(_lon[None, :])) * np.cos(np.deg2rad(_lat[:, None]) * 2)
         _monopole = np.cos(np.deg2rad(_lon[None, :])) * np.sin(np.deg2rad(_lat[:, None]) * 2)
-        shape = (91, 121)
-        grid = {
+        grid = ekg.grids.Grid({
             "grid": [1.0, 1.0],
-            "area": [max(_lat), min(_lon), min(_lat), max(_lon)],
-        }
+            "area": [max(_lat).item(), min(_lon).item(), min(_lat).item(), max(_lon).item()],
+        })
+
+        def __init__(self):
+            super().__init__(["a", "b", "c"], grid=self.grid, xp=np)
 
         def patterns(self, multiple=False):
             out = np.asarray([self._dipole, self._monopole, -self._dipole])
@@ -82,9 +86,14 @@ def test_project_maintains_shape(patterns):
     assert proj.shape == (2, 3, 4, 3)
 
 
-@pytest.mark.xfail(reason="grid info not available from earthkit-geo")
-def test_project_generates_weights_by_default(patterns):
-    array.project(np.ones(patterns.shape), patterns)
+def test_project_generates_coslat_weights_by_default(patterns):
+    result = array.project(np.ones(patterns.shape), patterns)
+
+    lat_2d = np.repeat(patterns._lat, patterns._lon.size).reshape(patterns.shape)
+    coslat = np.cos(np.deg2rad(lat_2d))
+    reference = array.project(np.ones(patterns.shape), patterns, weights=coslat)
+
+    np.testing.assert_allclose(result, reference)
 
 
 def test_project_with_single_pattern_return(patterns):

--- a/tests/regimes/array/test_index.py
+++ b/tests/regimes/array/test_index.py
@@ -9,7 +9,7 @@
 import numpy as np
 import pytest
 
-ekg = pytest.importorskip("earthkit.geo")
+ekg = pytest.importorskip("earthkit.geo", reason="regimes require earthkit.geo")
 
 from earthkit.meteo.regimes import Patterns, array
 

--- a/tests/regimes/fieldlist/__init__.py
+++ b/tests/regimes/fieldlist/__init__.py
@@ -1,0 +1,7 @@
+# (C) Copyright 2026- ECMWF and individual contributors.
+
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation nor
+# does it submit to any jurisdiction.

--- a/tests/regimes/fieldlist/test_index.py
+++ b/tests/regimes/fieldlist/test_index.py
@@ -45,7 +45,7 @@ def fields():
 
 @pytest.mark.parametrize("weights", [None, np.asarray([[1.0, 1.0]]), np.asarray([[0.2, 0.8]])])
 def test_project_with_constant_patterns(fields, weights):
-    patterns = ConstantPatterns(labels=["foo", "bar"], grid=GRID_SPEC, patterns=[[[1.0, 1.0]], [[0.1, 0.9]]])
+    patterns = ConstantPatterns(labels=["foo", "bar"], patterns=[[[1.0, 1.0]], [[0.1, 0.9]]], grid=GRID_SPEC)
     result = fieldlist.project(fields, patterns, weights)
     reference = array.project(fields.data(keys="value", flatten=False), patterns, weights)
 
@@ -57,13 +57,16 @@ def test_project_with_constant_patterns(fields, weights):
 def test_project_with_valid_time_dependent_patterns(fields, weights):
     patterns = ModulatedPatterns(
         labels=["foo", "bar"],
-        grid=GRID_SPEC,
         base_patterns=[[[1.0, 1.0]], [[0.1, 0.9]]],
         modulator=lambda t: pd.to_datetime(t).hour,
+        grid=GRID_SPEC,
     )
-    result = fieldlist.project(fields, patterns, weights, t="time.valid_datetime")
+    result = fieldlist.project(fields, patterns, weights, patterns_coords={"t": "time.valid_datetime"})
     reference = array.project(
-        fields.data(keys="value", flatten=False), patterns, weights, t=fields.get("time.valid_datetime")
+        fields.data(keys="value", flatten=False),
+        patterns,
+        weights,
+        patterns_coords={"t": fields.get("time.valid_datetime")},
     )
 
     assert result.shape == (4, 2)

--- a/tests/regimes/fieldlist/test_index.py
+++ b/tests/regimes/fieldlist/test_index.py
@@ -47,7 +47,7 @@ def fields():
 @pytest.mark.parametrize("weights", [None, np.asarray([[1.0, 1.0]]), np.asarray([[0.2, 0.8]])])
 def test_project_with_constant_patterns(fields, weights):
     patterns = ConstantPatterns(labels=["foo", "bar"], patterns=[[[1.0, 1.0]], [[0.1, 0.9]]], grid=GRID_SPEC)
-    result = fieldlist.project(fields, patterns, weights)
+    result = fieldlist.project(fields, patterns, weights, regrid_to_patterns=False)
     reference = array.project(fields.data(keys="value", flatten=False), patterns, weights)
     assert result.shape == (4, 2)
     np.testing.assert_array_equal(result, reference)
@@ -61,7 +61,9 @@ def test_project_with_valid_time_dependent_patterns(fields, weights):
         modulator=lambda t: pd.to_datetime(t).hour,
         grid=GRID_SPEC,
     )
-    result = fieldlist.project(fields, patterns, weights, patterns_coords={"t": "time.valid_datetime"})
+    result = fieldlist.project(
+        fields, patterns, weights, patterns_coords={"t": "time.valid_datetime"}, regrid_to_patterns=False
+    )
     reference = array.project(
         fields.data(keys="value", flatten=False),
         patterns,
@@ -85,5 +87,5 @@ def test_project_with_regrid_to_pattern():
             [[2.0, 2.0], [2.0, 2.0]],
         ]),
     )
-    result = fieldlist.project(field, patterns, weights=np.ones((2, 2)), regrid_to_pattern=True)
+    result = fieldlist.project(field, patterns, weights=np.ones((2, 2)), regrid_to_patterns=True)
     np.testing.assert_allclose(result, [[1.0, 2.0]])

--- a/tests/regimes/fieldlist/test_index.py
+++ b/tests/regimes/fieldlist/test_index.py
@@ -1,0 +1,58 @@
+# (C) Copyright 2026- ECMWF and individual contributors.
+
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation nor
+# does it submit to any jurisdiction.
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from earthkit.meteo.utils.testing import NO_EKD
+
+pytestmark = pytest.mark.skipif(NO_EKD, reason="EKD is not installed")
+
+from earthkit.meteo.regimes import ConstantPatterns, ModulatedPatterns, array, fieldlist
+
+GRIDSPEC = {"grid": [1.0, 1.0], "area": [45.0, 0.0, 45.0, 1.0]}
+
+
+@pytest.fixture
+def fields():
+    from earthkit.data import Field, FieldList
+
+    return FieldList.from_fields([
+        Field.from_components(values=np.asarray([[1.0, 1.0]]), time={"base_datetime": "2020-01-01T00:00", "step": 0}),
+        Field.from_components(values=np.asarray([[1.0, 6.0]]), time={"base_datetime": "2020-01-01T00:00", "step": 3}),
+        Field.from_components(values=np.asarray([[6.0, 1.0]]), time={"base_datetime": "2020-01-01T00:00", "step": 6}),
+        Field.from_components(values=np.asarray([[6.0, 6.0]]), time={"base_datetime": "2020-01-01T00:00", "step": 9}),
+    ])
+
+
+@pytest.mark.parametrize("weights", [np.asarray([[1.0, 1.0]]), np.asarray([[0.2, 0.8]])])
+def test_project_with_constant_patterns(fields, weights):
+    patterns = ConstantPatterns(labels=["foo", "bar"], grid=GRIDSPEC, patterns=[[[1.0, 1.0]], [[0.1, 0.9]]])
+    result = fieldlist.project(fields, patterns, weights)
+    reference = array.project(fields.values[:, None, :], patterns, weights)
+
+    assert result.shape == (4, 2)
+    np.testing.assert_allclose(result["foo"], reference["foo"])
+    np.testing.assert_allclose(result["bar"], reference["bar"])
+
+
+@pytest.mark.parametrize("weights", [np.asarray([[1.0, 1.0]]), np.asarray([[0.2, 0.8]])])
+def test_project_with_valid_time_dependent_patterns(fields, weights):
+    patterns = ModulatedPatterns(
+        labels=["foo", "bar"],
+        grid=GRIDSPEC,
+        base_patterns=[[[1.0, 1.0]], [[0.1, 0.9]]],
+        modulator=lambda t: pd.to_datetime(t).hour,
+    )
+    result = fieldlist.project(fields, patterns, weights, t="time.valid_datetime")
+    reference = array.project(fields.values[:, None, :], patterns, weights, t=fields.get("time.valid_datetime"))
+
+    assert result.shape == (4, 2)
+    np.testing.assert_allclose(result["foo"], reference["foo"])
+    np.testing.assert_allclose(result["bar"], reference["bar"])

--- a/tests/regimes/fieldlist/test_index.py
+++ b/tests/regimes/fieldlist/test_index.py
@@ -10,49 +10,61 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from earthkit.meteo.utils.testing import NO_EKD
-
-pytestmark = pytest.mark.skipif(NO_EKD, reason="EKD is not installed")
+ekd = pytest.importorskip("earthkit.data")
 
 from earthkit.meteo.regimes import ConstantPatterns, ModulatedPatterns, array, fieldlist
 
-GRIDSPEC = {"grid": [1.0, 1.0], "area": [45.0, 0.0, 45.0, 1.0]}
+GRID_SPEC = {"grid": [1.0, 1.0], "area": [45.0, 0.0, 45.0, 1.0]}
 
 
 @pytest.fixture
 def fields():
-    from earthkit.data import Field, FieldList
-
-    return FieldList.from_fields([
-        Field.from_components(values=np.asarray([[1.0, 1.0]]), time={"base_datetime": "2020-01-01T00:00", "step": 0}),
-        Field.from_components(values=np.asarray([[1.0, 6.0]]), time={"base_datetime": "2020-01-01T00:00", "step": 3}),
-        Field.from_components(values=np.asarray([[6.0, 1.0]]), time={"base_datetime": "2020-01-01T00:00", "step": 6}),
-        Field.from_components(values=np.asarray([[6.0, 6.0]]), time={"base_datetime": "2020-01-01T00:00", "step": 9}),
+    return ekd.FieldList.from_fields([
+        ekd.Field.from_components(
+            values=np.asarray([[1.0, 1.0]]),
+            time={"base_datetime": "2020-01-01T00:00", "step": 0},
+            geography={"grid_spec": GRID_SPEC},
+        ),
+        ekd.Field.from_components(
+            values=np.asarray([[1.0, 6.0]]),
+            time={"base_datetime": "2020-01-01T00:00", "step": 3},
+            geography={"grid_spec": GRID_SPEC},
+        ),
+        ekd.Field.from_components(
+            values=np.asarray([[6.0, 1.0]]),
+            time={"base_datetime": "2020-01-01T00:00", "step": 6},
+            geography={"grid_spec": GRID_SPEC},
+        ),
+        ekd.Field.from_components(
+            values=np.asarray([[6.0, 6.0]]),
+            time={"base_datetime": "2020-01-01T00:00", "step": 9},
+            geography={"grid_spec": GRID_SPEC},
+        ),
     ])
 
 
-@pytest.mark.parametrize("weights", [np.asarray([[1.0, 1.0]]), np.asarray([[0.2, 0.8]])])
+@pytest.mark.parametrize("weights", [None, np.asarray([[1.0, 1.0]]), np.asarray([[0.2, 0.8]])])
 def test_project_with_constant_patterns(fields, weights):
-    patterns = ConstantPatterns(labels=["foo", "bar"], grid=GRIDSPEC, patterns=[[[1.0, 1.0]], [[0.1, 0.9]]])
+    patterns = ConstantPatterns(labels=["foo", "bar"], grid=GRID_SPEC, patterns=[[[1.0, 1.0]], [[0.1, 0.9]]])
     result = fieldlist.project(fields, patterns, weights)
-    reference = array.project(fields.values[:, None, :], patterns, weights)
+    reference = array.project(fields.data(keys="value", flatten=False), patterns, weights)
 
     assert result.shape == (4, 2)
-    np.testing.assert_allclose(result["foo"], reference["foo"])
-    np.testing.assert_allclose(result["bar"], reference["bar"])
+    np.testing.assert_allclose(result, reference)
 
 
-@pytest.mark.parametrize("weights", [np.asarray([[1.0, 1.0]]), np.asarray([[0.2, 0.8]])])
+@pytest.mark.parametrize("weights", [None, np.asarray([[1.0, 1.0]]), np.asarray([[0.2, 0.8]])])
 def test_project_with_valid_time_dependent_patterns(fields, weights):
     patterns = ModulatedPatterns(
         labels=["foo", "bar"],
-        grid=GRIDSPEC,
+        grid=GRID_SPEC,
         base_patterns=[[[1.0, 1.0]], [[0.1, 0.9]]],
         modulator=lambda t: pd.to_datetime(t).hour,
     )
     result = fieldlist.project(fields, patterns, weights, t="time.valid_datetime")
-    reference = array.project(fields.values[:, None, :], patterns, weights, t=fields.get("time.valid_datetime"))
+    reference = array.project(
+        fields.data(keys="value", flatten=False), patterns, weights, t=fields.get("time.valid_datetime")
+    )
 
     assert result.shape == (4, 2)
-    np.testing.assert_allclose(result["foo"], reference["foo"])
-    np.testing.assert_allclose(result["bar"], reference["bar"])
+    np.testing.assert_allclose(result, reference)

--- a/tests/regimes/fieldlist/test_index.py
+++ b/tests/regimes/fieldlist/test_index.py
@@ -11,6 +11,7 @@ import pandas as pd
 import pytest
 
 ekd = pytest.importorskip("earthkit.data")
+ekg = pytest.importorskip("earthkit.geo", reason="regimes require earthkit.geo")
 
 from earthkit.meteo.regimes import ConstantPatterns, ModulatedPatterns, array, fieldlist
 
@@ -50,7 +51,6 @@ def test_project_with_constant_patterns(fields, weights):
     reference = array.project(fields.data(keys="value", flatten=False), patterns, weights)
     assert result.shape == (4, 2)
     np.testing.assert_array_equal(result, reference)
-    np.testing.assert_array_equal(result.columns, ["bar", "foo"])
 
 
 @pytest.mark.parametrize("weights", [None, np.asarray([[1.0, 1.0]]), np.asarray([[0.2, 0.8]])])
@@ -70,10 +70,9 @@ def test_project_with_valid_time_dependent_patterns(fields, weights):
     )
     assert result.shape == (4, 2)
     np.testing.assert_array_equal(result, reference)
-    np.testing.assert_array_equal(result.columns, ["foo", "bar"])
 
 
-def test_project_with_automatic_regridding():
+def test_project_with_regrid_to_pattern():
     field = ekd.Field.from_components(
         values=np.asarray([[0.0, 0.0, 0.0, 0.0], [0.0, 1.0, 1.0, 0.0], [0.0, 1.0, 1.0, 0.0]]),
         geography={"grid_spec": {"grid": [1.0, 1.0], "area": [46.0, -1.0, 44.0, 2.0]}},
@@ -86,5 +85,5 @@ def test_project_with_automatic_regridding():
             [[2.0, 2.0], [2.0, 2.0]],
         ]),
     )
-    result = fieldlist.project(field, patterns, weights=np.ones((2, 2)))
+    result = fieldlist.project(field, patterns, weights=np.ones((2, 2)), regrid_to_pattern=True)
     np.testing.assert_allclose(result, [[1.0, 2.0]])

--- a/tests/regimes/fieldlist/test_index.py
+++ b/tests/regimes/fieldlist/test_index.py
@@ -75,6 +75,7 @@ def test_project_with_valid_time_dependent_patterns(fields, weights):
 
 
 def test_project_with_regrid_to_pattern():
+    pytest.importorskip("mir", reason="MIR not available for regridding")
     field = ekd.Field.from_components(
         values=np.asarray([[0.0, 0.0, 0.0, 0.0], [0.0, 1.0, 1.0, 0.0], [0.0, 1.0, 1.0, 0.0]]),
         geography={"grid_spec": {"grid": [1.0, 1.0], "area": [46.0, -1.0, 44.0, 2.0]}},

--- a/tests/regimes/fieldlist/test_index.py
+++ b/tests/regimes/fieldlist/test_index.py
@@ -48,9 +48,9 @@ def test_project_with_constant_patterns(fields, weights):
     patterns = ConstantPatterns(labels=["foo", "bar"], patterns=[[[1.0, 1.0]], [[0.1, 0.9]]], grid=GRID_SPEC)
     result = fieldlist.project(fields, patterns, weights)
     reference = array.project(fields.data(keys="value", flatten=False), patterns, weights)
-
     assert result.shape == (4, 2)
-    np.testing.assert_allclose(result, reference)
+    np.testing.assert_array_equal(result, reference)
+    np.testing.assert_array_equal(result.columns, ["bar", "foo"])
 
 
 @pytest.mark.parametrize("weights", [None, np.asarray([[1.0, 1.0]]), np.asarray([[0.2, 0.8]])])
@@ -68,6 +68,23 @@ def test_project_with_valid_time_dependent_patterns(fields, weights):
         weights,
         patterns_coords={"t": fields.get("time.valid_datetime")},
     )
-
     assert result.shape == (4, 2)
-    np.testing.assert_allclose(result, reference)
+    np.testing.assert_array_equal(result, reference)
+    np.testing.assert_array_equal(result.columns, ["foo", "bar"])
+
+
+def test_project_with_automatic_regridding():
+    field = ekd.Field.from_components(
+        values=np.asarray([[0.0, 0.0, 0.0, 0.0], [0.0, 1.0, 1.0, 0.0], [0.0, 1.0, 1.0, 0.0]]),
+        geography={"grid_spec": {"grid": [1.0, 1.0], "area": [46.0, -1.0, 44.0, 2.0]}},
+    )
+    patterns = ConstantPatterns(
+        labels=["foo", "bar"],
+        grid={"grid": [1.0, 1.0], "area": [45.0, 0.0, 44.0, 1.0]},
+        patterns=np.asarray([
+            [[1.0, 1.0], [1.0, 1.0]],
+            [[2.0, 2.0], [2.0, 2.0]],
+        ]),
+    )
+    result = fieldlist.project(field, patterns, weights=np.ones((2, 2)))
+    np.testing.assert_allclose(result, [[1.0, 2.0]])

--- a/tests/regimes/test_index.py
+++ b/tests/regimes/test_index.py
@@ -9,9 +9,14 @@
 import numpy as np
 import pytest
 
+pytest.importorskip("earthkit.geo", reason="regimes require earthkit-geo")
+
 from earthkit.meteo import regimes
 from earthkit.meteo.regimes import array as regimes_array
+from earthkit.meteo.regimes import fieldlist as regimes_fieldlist
 from earthkit.meteo.regimes import xarray as regimes_xarray
+
+GRID_SPEC = {"grid": [1.0, 1.0], "area": [45.0, 0.0, 45.0, 1.0]}
 
 
 @pytest.fixture
@@ -19,7 +24,7 @@ def patterns():
     return regimes.ConstantPatterns(
         labels=["foo", "bar"],
         patterns=[[[1.0, 1.0]], [[0.1, 0.9]]],
-        grid={"grid": [1.0, 1.0], "area": [45.0, 0.0, 45.0, 1.0]},
+        grid=GRID_SPEC,
     )
 
 
@@ -82,3 +87,29 @@ def test_highlevel_regime_index_dispatches_to_xarray(xarray_data3d):
     ref = regimes_xarray.regime_index(xarray_data3d, mean, std)
 
     xr.testing.assert_allclose(got, ref)
+
+
+ekd = pytest.importorskip("earthkit.data")
+
+
+@pytest.fixture
+def fieldlist_data():
+    return ekd.FieldList.from_fields([
+        ekd.Field.from_components(
+            values=np.asarray([[1.0, 1.0]]),
+            time={"base_datetime": "2020-01-01T00:00", "step": 0},
+            geography={"grid_spec": GRID_SPEC},
+        ),
+        ekd.Field.from_components(
+            values=np.asarray([[1.0, 6.0]]),
+            time={"base_datetime": "2020-01-01T00:00", "step": 3},
+            geography={"grid_spec": GRID_SPEC},
+        ),
+    ])
+
+
+def test_highlevel_project_dispatches_to_fieldlist(fieldlist_data, patterns):
+    got = regimes.project(fieldlist_data, patterns)
+    ref = regimes_fieldlist.project(fieldlist_data, patterns)
+
+    np.testing.assert_allclose(got, ref)

--- a/tests/regimes/test_patterns.py
+++ b/tests/regimes/test_patterns.py
@@ -9,6 +9,8 @@
 import numpy as np
 import pytest
 
+ekg = pytest.importorskip("earthkit.geo")
+
 from earthkit.meteo import regimes
 
 
@@ -24,7 +26,7 @@ class TestConstantPatterns:
             labels=["dipole", "monopole", "dipole_inv"],
             grid={
                 "grid": [1.0, 1.0],
-                "area": [max(self.lat), min(self.lon), min(self.lat), max(self.lon)],
+                "area": [max(self.lat).item(), min(self.lon).item(), min(self.lat).item(), max(self.lon).item()],
             },
             patterns=np.stack([self.dipole, self.monopole, -self.dipole]).copy(),
         )
@@ -45,6 +47,9 @@ class TestConstantPatterns:
         assert len(patterns) == 3
         assert len(patterns) == len(patterns.labels)
 
+    def test_grid(self, patterns):
+        assert isinstance(patterns.grid, ekg.grids.Grid)
+
     def test_patterns(self, patterns):
         pat = patterns.patterns()
         assert pat.shape == (3, 91, 121)
@@ -63,7 +68,7 @@ class TestModulatedPatterns:
             labels=["dipole"],
             grid={
                 "grid": [1.0, 1.0],
-                "area": [max(self.lat), min(self.lon), min(self.lat), max(self.lon)],
+                "area": [max(self.lat).item(), min(self.lon).item(), min(self.lat).item(), max(self.lon).item()],
             },
             base_patterns=np.stack([self.dipole]).copy(),
             modulator=lambda x, y: y * np.sign(x),
@@ -84,6 +89,9 @@ class TestModulatedPatterns:
             },
             dims=["foo", "bar", "baz", "lat", "lon"],
         )
+
+    def test_grid(self, patterns):
+        assert isinstance(patterns.grid, ekg.grids.Grid)
 
     def test_shape(self, patterns):
         assert patterns.shape == (self.lat.size, self.lon.size)

--- a/tests/regimes/test_patterns.py
+++ b/tests/regimes/test_patterns.py
@@ -9,7 +9,7 @@
 import numpy as np
 import pytest
 
-ekg = pytest.importorskip("earthkit.geo")
+ekg = pytest.importorskip("earthkit.geo", reason="regimes require earthkit-geo")
 
 from earthkit.meteo import regimes
 

--- a/tests/regimes/test_weights.py
+++ b/tests/regimes/test_weights.py
@@ -1,7 +1,0 @@
-# (C) Copyright 2026- ECMWF and individual contributors.
-
-# This software is licensed under the terms of the Apache Licence Version 2.0
-# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-# In applying this licence, ECMWF does not waive the privileges and immunities
-# granted to it by virtue of its status as an intergovernmental organisation nor
-# does it submit to any jurisdiction.

--- a/tests/regimes/test_weights.py
+++ b/tests/regimes/test_weights.py
@@ -1,0 +1,7 @@
+# (C) Copyright 2026- ECMWF and individual contributors.
+
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation nor
+# does it submit to any jurisdiction.

--- a/tests/regimes/xarray/test_index.py
+++ b/tests/regimes/xarray/test_index.py
@@ -38,7 +38,7 @@ def data3d():
 def patterns():
     class MockPatternsForData3d(Patterns):
         def __init__(self):
-            grid = {"grid": [1.0, 1.0], "area": [46.0, 0.0, 45.0, 3.0]}
+            grid = ekg.grids.Grid({"grid": [10.0, 10.0], "area": [60.0, -10.0, 50.0, 20.0]})
             super().__init__(["a", "b"], grid=grid, xp=np)
 
         def patterns(self, **kwargs):
@@ -85,14 +85,15 @@ def test_project_with_full_dimensional_weights(data3d, patterns):
 
 def test_project_ensures_weight_dims_are_pattern_dims(data3d, patterns):
     with pytest.raises(ValueError):
-        project(data3d, patterns, weights=data3d, foo="foo")  # dimension foo is not a pattern dim
+        project(data3d, patterns, weights=data3d, patterns_coords=["foo"])  # dimension foo is not a pattern dim
 
 
 def test_project_with_weights_generation(data3d, patterns):
-    result = project(data3d, patterns, foo="foo")
+    result = project(data3d, patterns, patterns_coords=["foo"])
     # Project with explicit cos(lat)-weights for reference
     weights = np.cos(np.deg2rad(data3d.coords["lat"]))
-    reference = project(data3d, patterns, weights=weights, foo="foo")
+    print(weights)
+    reference = project(data3d, patterns, weights=weights, patterns_coords=["foo"])
     xr.testing.assert_allclose(result, reference)
 
 

--- a/tests/regimes/xarray/test_index.py
+++ b/tests/regimes/xarray/test_index.py
@@ -10,6 +10,7 @@ import numpy as np
 import pytest
 
 xr = pytest.importorskip("xarray")
+ekg = pytest.importorskip("earthkit.geo")
 
 from earthkit.meteo.regimes import Patterns
 from earthkit.meteo.regimes.xarray import project, regime_index
@@ -35,7 +36,7 @@ def data3d():
 
 @pytest.fixture
 def patterns():
-    class MockPatterns(Patterns):
+    class MockPatternsForData3d(Patterns):
         def __init__(self):
             grid = {"grid": [1.0, 1.0], "area": [46.0, 0.0, 45.0, 3.0]}
             super().__init__(["a", "b"], grid=grid, xp=np)
@@ -50,7 +51,7 @@ def patterns():
                 return kwargs["foo"][..., None, None, None] * out
             return out
 
-    return MockPatterns()
+    return MockPatternsForData3d()
 
 
 def test_project_with_with_lower_dimensional_weights(data3d, patterns, weights1d):
@@ -84,7 +85,15 @@ def test_project_with_full_dimensional_weights(data3d, patterns):
 
 def test_project_ensures_weight_dims_are_pattern_dims(data3d, patterns):
     with pytest.raises(ValueError):
-        project(data3d, patterns, weights=data3d)  # dimension foo is not a pattern dim
+        project(data3d, patterns, weights=data3d, foo="foo")  # dimension foo is not a pattern dim
+
+
+def test_project_with_weights_generation(data3d, patterns):
+    result = project(data3d, patterns, foo="foo")
+    # Project with explicit cos(lat)-weights for reference
+    weights = np.cos(np.deg2rad(data3d.coords["lat"]))
+    reference = project(data3d, patterns, weights=weights, foo="foo")
+    xr.testing.assert_allclose(result, reference)
 
 
 def test_project_without_patterns_coords(data3d, patterns, weights1d):

--- a/tests/regimes/xarray/test_index.py
+++ b/tests/regimes/xarray/test_index.py
@@ -10,7 +10,7 @@ import numpy as np
 import pytest
 
 xr = pytest.importorskip("xarray")
-ekg = pytest.importorskip("earthkit.geo")
+ekg = pytest.importorskip("earthkit.geo", reason="regimes require earthkit.geo")
 
 from earthkit.meteo.regimes import Patterns
 from earthkit.meteo.regimes.xarray import project, regime_index
@@ -92,7 +92,6 @@ def test_project_with_weights_generation(data3d, patterns):
     result = project(data3d, patterns, patterns_coords=["foo"])
     # Project with explicit cos(lat)-weights for reference
     weights = np.cos(np.deg2rad(data3d.coords["lat"]))
-    print(weights)
     reference = project(data3d, patterns, weights=weights, patterns_coords=["foo"])
     xr.testing.assert_allclose(result, reference)
 


### PR DESCRIPTION
### Description

- [x] Add a FieldList implementation for `regimes.project`.
- [x] Use earthkit-geo's `Grid` to replace grid spec polyfill for the patterns grid specification. Fully backwards compatible as Grid constructor accepts the previously used grid spec dictionaries.
- [x] Enable automatic area-based weights generation for regular-ll grids.
- [x] Enable automatic regridding of fields to match the patterns grid (only FieldList implementation for now).
- [x] Update the documentation.

Makes earthkit-geo a hard requirement of the regimes submodule. A new optional dependency group `regimes` is added and earthkit-geo is also added as a requirement of the `test` dependency group.

### Questions

- The downstream-ci currently skips the regridding test due to MIR not being available. Should I make MIR available in the test environment with an additional dependency?
- The regime indices are currently returned as plain arrays for the fieldlist implementation. This means the results work out-of-the-box with the dispatcher for `regime_index`, which most users will call as a follow-up. It's just not very nice in terms of metadata. There would be more information available to provide proper labels and coordinates for the values. The output of the function is tabular data and I'm wondering what the most suitable earthkit-data-aligned container for that is? A pandas DataFrame? And should it be a generator to accommodate streamed fieldlists? I'd be happy to mark the FieldList implementation as experimental until that is sorted out.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
