### PR TITLE
Rename coord to coords in interpolate_monotonic

### DIFF
--- a/docs/how-tos/regimes/seven_weather_regimes.ipynb
+++ b/docs/how-tos/regimes/seven_weather_regimes.ipynb
@@ -3,10 +3,28 @@
   {
    "cell_type": "markdown",
    "id": "9485a729",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
-    "# Year-round North Atlantic-European Weather Regimes\n",
-    "\n",
+    "# Regimes: year-round North Atlantic-European Weather Regimes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0581c9d4-a4db-48c2-b685-86e4299ae9a7",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
     "Following the example in Part 4 of [github.com/cmgrams/wr_data_package_era5](https://github.com/cmgrams/wr_data_package_era5/blob/main/wr_data_package_V1.0/scripts_first_steps/WR_read_example.ipynb), compute the regime index for the seven-regime classification of [Grams (2026, in review)](https://doi.org/10.5194/egusphere-2025-6385)."
    ]
   },
@@ -14,7 +32,13 @@
    "cell_type": "code",
    "execution_count": 1,
    "id": "38c63573",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -1488,7 +1512,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "earthkit-meteo",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -1502,7 +1526,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.14.4"
+   "version": "3.13.1"
   }
  },
  "nbformat": 4,

--- a/docs/how-tos/stats/return_period.ipynb
+++ b/docs/how-tos/stats/return_period.ipynb
@@ -2,15 +2,27 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
-    "# Estimating return periods of extreme values"
+    "# Stats: estimating return periods of extreme values"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "import earthkit.data as ekd\n",
@@ -169,7 +181,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "earthkit-meteo",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -183,9 +195,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.14.0"
+   "version": "3.13.1"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/docs/how-tos/vertical/hybrid_levels_array.ipynb
+++ b/docs/how-tos/vertical/hybrid_levels_array.ipynb
@@ -11,7 +11,7 @@
     "tags": []
    },
    "source": [
-    "## Computing values on hybrid levels"
+    "# Vertical (Array): computing values on hybrid levels"
    ]
   },
   {
@@ -59,11 +59,11 @@
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "raw",
    "id": "4939f1ab-e2bc-444d-825a-6b9e250fe838",
    "metadata": {
     "editable": true,
-    "raw_mimetype": "text/restructuredtext",
+    "raw_mimetype": "text/x-rst",
     "slideshow": {
      "slide_type": ""
     },
@@ -72,7 +72,7 @@
    "source": [
     "Hybrid levels divide the atmosphere into layers. These layers are defined by the pressures at the interfaces between them, which are the **half-levels**. The half-levels are defined by a set A and B coefficients in such a way that at the top of the atmosphere the first half level pressure is a constant, while at the bottom the last one is the surface pressure. The **full-level** pressure associated with each model level is defined as the middle of the layer. As a consequence, the bottom-most (full) model level is always above the surface. Please note that by convention the model level numbering starts at 1 at the top of the atmosphere and increases towards the surface.\n",
     "\n",
-    "For more details about the hybrid levels see [IFS Documentation CY47R3 - Part IV Physical processes, Chapter 2, Section 2.2.1.](https://www.ecmwf.int/en/elibrary/20198-ifs-documentation-cy47r3-part-iv-physical-processes)"
+    "For more details about the hybrid levels see [IFS-CY49R1-Dynamics]_ Chapter 2, Section 2.2.1."
    ]
   },
   {

--- a/docs/how-tos/vertical/interpolate_hybrid_to_hl_array.ipynb
+++ b/docs/how-tos/vertical/interpolate_hybrid_to_hl_array.ipynb
@@ -11,7 +11,7 @@
     "tags": []
    },
    "source": [
-    "## Interpolating from hybrid to height levels"
+    "# Vertical (Array): interpolating from hybrid to height levels"
    ]
   },
   {
@@ -49,7 +49,7 @@
    "id": "f4d807e1-f3f1-4f0f-bcda-1f7718735898",
    "metadata": {
     "editable": true,
-    "raw_mimetype": "text/restructuredtext",
+    "raw_mimetype": "text/x-rst",
     "slideshow": {
      "slide_type": ""
     },
@@ -61,7 +61,7 @@
    "source": [
     "Hybrid levels are terrain following at the bottom and isobaric at the top of the atmosphere with a transition in between. This is the vertical coordinate system in the IFS model. \n",
     "\n",
-    "For details about the hybrid levels see  `IFS Documentation CY47R3 - Part IV Physical processes, Chapter 2, Section 2.2.1. <https://www.ecmwf.int/en/elibrary/20198-ifs-documentation-cy47r3-part-iv-physical-processes>`_. Also see the :ref:`/how-tos/hybrid_levels.ipynb` notebook for the related computations in earthkit-meteo."
+    "For details about the hybrid levels see  [IFS-CY49R1-Dynamics]_ Chapter 2, Section 2.2.1. `IFS Documentation CY47R3 - Part IV Physical processes, Chapter 2, Section 2.2.1. Also see the :ref:`/how-tos/vertical/hybrid_levels_array.ipynb` notebook for the related computations in earthkit-meteo."
    ]
   },
   {

--- a/docs/how-tos/vertical/interpolate_hybrid_to_pl_array.ipynb
+++ b/docs/how-tos/vertical/interpolate_hybrid_to_pl_array.ipynb
@@ -11,7 +11,7 @@
     "tags": []
    },
    "source": [
-    "## Interpolating from hybrid to pressure levels"
+    "# Vertical(Array): interpolating from hybrid to pressure levels"
    ]
   },
   {
@@ -49,7 +49,7 @@
    "id": "68c2e2c1-5e21-4b52-9dd1-131bee484ba1",
    "metadata": {
     "editable": true,
-    "raw_mimetype": "text/restructuredtext",
+    "raw_mimetype": "text/x-rst",
     "slideshow": {
      "slide_type": ""
     },
@@ -61,7 +61,7 @@
    "source": [
     "Hybrid levels are terrain following at the bottom and isobaric at the top of the atmosphere with a transition in between. This is the vertical coordinate system in the IFS model. \n",
     "\n",
-    "For details about the hybrid levels see  `IFS Documentation CY47R3 - Part IV Physical processes, Chapter 2, Section 2.2.1. <https://www.ecmwf.int/en/elibrary/20198-ifs-documentation-cy47r3-part-iv-physical-processes>`_. Also see the :ref:`/how-tos/hybrid_levels.ipynb` notebook for the related computations in earthkit-meteo."
+    "For details about the hybrid levels see  [IFS-CY49R1-Dynamics]_ Chapter 2, Section 2.2.1. `IFS Documentation CY47R3 - Part IV Physical processes, Chapter 2, Section 2.2.1. Also see the :ref:`/how-tos/vertical/hybrid_levels_array.ipynb` notebook for the related computations in earthkit-meteo."
    ]
   },
   {

--- a/docs/how-tos/vertical/interpolate_pl_to_hl_array.ipynb
+++ b/docs/how-tos/vertical/interpolate_pl_to_hl_array.ipynb
@@ -11,7 +11,7 @@
     "tags": []
    },
    "source": [
-    "## Interpolating from pressure to height levels"
+    "# Vertical (Array): interpolating from pressure to height levels"
    ]
   },
   {

--- a/docs/how-tos/vertical/interpolate_pl_to_pl_array.ipynb
+++ b/docs/how-tos/vertical/interpolate_pl_to_pl_array.ipynb
@@ -11,7 +11,7 @@
     "tags": []
    },
    "source": [
-    "## Interpolating from pressure to pressure levels"
+    "# Vertical (Array): interpolating from pressure to pressure levels"
    ]
   },
   {

--- a/docs/tutorials/input/index.rst
+++ b/docs/tutorials/input/index.rst
@@ -1,4 +1,4 @@
-.. _vertical-tutorials:
+.. _input-tutorials:
 
 Input
 ++++++++++++++

--- a/docs/tutorials/vertical/interpolate_hybrid_to_hl_fieldlist.ipynb
+++ b/docs/tutorials/vertical/interpolate_hybrid_to_hl_fieldlist.ipynb
@@ -31,7 +31,7 @@
     "- :py:meth:`~earthkit.meteo.vertical.fieldlist.interpolate_hybrid_to_height_levels`. This is a convenience method dedicated to this particular interpolation. \n",
     "- :py:meth:`~earthkit.meteo.vertical.fieldlist.interpolate_monotonic`. This is a generic method and requires an extra step to compute the height on hybrid levels, which then it can be applied to multiple interpolations.\n",
     "\n",
-    "We will use :ref:`earthkit-data` for fieldlist support and :ref:`earthkit-plots` for plotting."
+    "We will use :xref:`earthkit-data` for fieldlist support and :xref:`earthkit-plots` for plotting."
    ]
   },
   {
@@ -82,7 +82,7 @@
    "source": [
     "Hybrid levels are terrain following at the bottom and isobaric at the top of the atmosphere with a transition in between. This is the vertical coordinate system in the IFS model.\n",
     "\n",
-    "For details about the hybrid levels see [IFS-CY49R1-Dynamics]_ Chapter 2, Section 2.2.1. Also see the :ref:`/how-tos/vertical/hybrid_levels_grib.ipynb` notebook for the related computations in earthkit-meteo."
+    "For details about the hybrid levels see [IFS-CY49R1-Dynamics]_ Chapter 2, Section 2.2.1. Also see the :ref:`/tutorials/vertical/hybrid_levels_fieldlist.ipynb` notebook for the related computations in earthkit-meteo."
    ]
   },
   {
@@ -128,7 +128,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "548af08c461b4ec49cef2a356f73cf37",
+       "model_id": "ac3f567a9f2a41d6805ee7329677b8ae",
        "version_major": 2,
        "version_minor": 0
       },
@@ -486,7 +486,7 @@
     {
      "data": {
       "text/plain": [
-       "<earthkit.plots.components.figures.Figure at 0x1777c74d0>"
+       "<earthkit.plots.components.figures.Figure at 0x12888f4d0>"
       ]
      },
      "execution_count": 5,
@@ -1067,7 +1067,7 @@
     {
      "data": {
       "text/plain": [
-       "<earthkit.plots.components.maps.Map at 0x179d2d090>"
+       "<earthkit.plots.components.maps.Map at 0x12ace91d0>"
       ]
      },
      "execution_count": 13,
@@ -1125,7 +1125,7 @@
     {
      "data": {
       "text/plain": [
-       "<earthkit.plots.components.maps.Map at 0x179de15b0>"
+       "<earthkit.plots.components.maps.Map at 0x12ad8d940>"
       ]
      },
      "execution_count": 14,
@@ -1191,7 +1191,7 @@
     {
      "data": {
       "text/plain": [
-       "<earthkit.plots.components.maps.Map at 0x179de2650>"
+       "<earthkit.plots.components.maps.Map at 0x12ad8e9e0>"
       ]
      },
      "execution_count": 15,
@@ -1273,7 +1273,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "d48ee1e688d342c3850aefc82b9605f0",
+       "model_id": "9555159bd97741f0ba00e05c34d946e7",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1483,7 +1483,7 @@
     {
      "data": {
       "text/plain": [
-       "<earthkit.plots.components.figures.Figure at 0x179de3360>"
+       "<earthkit.plots.components.figures.Figure at 0x12ad8f6f0>"
       ]
      },
      "execution_count": 18,
@@ -1686,7 +1686,7 @@
     "target_h = [1000.0, 5000.0]  # geometric height (m), above the ground\n",
     "\n",
     "t_res = vertical.interpolate_monotonic(\n",
-    "    t, coord=h, target_coord=target_h, coord_type=\"height_above_ground_level\", interpolation=\"linear\"\n",
+    "    t, coords=h, target_coords=target_h, coord_type=\"height_above_ground_level\", interpolation=\"linear\"\n",
     ")\n",
     "t_res.ls()"
    ]
@@ -1735,7 +1735,7 @@
     {
      "data": {
       "text/plain": [
-       "<earthkit.plots.components.figures.Figure at 0x179e86450>"
+       "<earthkit.plots.components.figures.Figure at 0x12ae539b0>"
       ]
      },
      "execution_count": 22,
@@ -1863,7 +1863,7 @@
    ],
    "source": [
     "q_res = vertical.interpolate_monotonic(\n",
-    "    q, coord=h, target_coord=target_h, coord_type=\"height_above_ground_level\", interpolation=\"linear\"\n",
+    "    q, coords=h, target_coords=target_h, coord_type=\"height_above_ground_level\", interpolation=\"linear\"\n",
     ")\n",
     "q_res.ls()"
    ]
@@ -1912,7 +1912,7 @@
     {
      "data": {
       "text/plain": [
-       "<earthkit.plots.components.figures.Figure at 0x17cfb3020>"
+       "<earthkit.plots.components.figures.Figure at 0x12c2b8af0>"
       ]
      },
      "execution_count": 25,
@@ -2040,7 +2040,7 @@
     "h_sea = vertical.height_on_hybrid_levels(t, q, zs, sp, h_type=\"geometric\", h_reference=\"sea\")\n",
     "\n",
     "t_res_sea = vertical.interpolate_monotonic(\n",
-    "    t, coord=h_sea, target_coord=target_h, coord_type=\"height_above_sea_level\", interpolation=\"linear\"\n",
+    "    t, coords=h_sea, target_coords=target_h, coord_type=\"height_above_sea_level\", interpolation=\"linear\"\n",
     ")\n",
     "t_res_sea.ls()"
    ]
@@ -2183,7 +2183,7 @@
     "h_gp = vertical.height_on_hybrid_levels(t, q, zs, sp, h_type=\"geopotential\", h_reference=\"ground\")\n",
     "\n",
     "t_res_gp = vertical.interpolate_monotonic(\n",
-    "    t, coord=h_gp, target_coord=target_h, coord_type=\"height_above_ground_level\", interpolation=\"linear\"\n",
+    "    t, coords=h_gp, target_coords=target_h, coord_type=\"height_above_ground_level\", interpolation=\"linear\"\n",
     ")\n",
     "t_res_gp.ls()"
    ]
@@ -2389,7 +2389,7 @@
     "h_sub = vertical.height_on_hybrid_levels(t_sub, q_sub, zs, sp, h_type=\"geometric\", h_reference=\"ground\")\n",
     "\n",
     "t_res_sub = vertical.interpolate_monotonic(\n",
-    "    t_sub, coord=h_sub, target_coord=target_h, coord_type=\"height_above_ground_level\", interpolation=\"linear\"\n",
+    "    t_sub, coords=h_sub, target_coords=target_h, coord_type=\"height_above_ground_level\", interpolation=\"linear\"\n",
     ")\n",
     "t_res_sub.ls()"
    ]
@@ -2469,7 +2469,7 @@
     {
      "data": {
       "text/plain": [
-       "<earthkit.plots.components.maps.Map at 0x179f7dd50>"
+       "<earthkit.plots.components.maps.Map at 0x12b07d950>"
       ]
      },
      "execution_count": 33,
@@ -2520,7 +2520,7 @@
     {
      "data": {
       "text/plain": [
-       "<earthkit.plots.components.maps.Map at 0x179f7f150>"
+       "<earthkit.plots.components.maps.Map at 0x12b07ed50>"
       ]
      },
      "execution_count": 34,
@@ -2542,7 +2542,7 @@
     "target_h_near_surf = [10.0]  # m above the ground\n",
     "\n",
     "t_res_nan = vertical.interpolate_monotonic(\n",
-    "    t, coord=h, target_coord=target_h_near_surf, coord_type=\"height_above_ground_level\", interpolation=\"linear\"\n",
+    "    t, coords=h, target_coords=target_h_near_surf, coord_type=\"height_above_ground_level\", interpolation=\"linear\"\n",
     ")\n",
     "\n",
     "# plot the result\n",
@@ -2589,8 +2589,8 @@
    "source": [
     "t_res_aux = vertical.interpolate_monotonic(\n",
     "    t,\n",
-    "    coord=h,\n",
-    "    target_coord=target_h_near_surf,\n",
+    "    coords=h,\n",
+    "    target_coords=target_h_near_surf,\n",
     "    coord_type=\"height_above_ground_level\",\n",
     "    aux_min_level_coord=0.0,  # m — height of the auxiliary level (surface)\n",
     "    aux_min_level_data=t[-1] + 0.06,  # K — set field as temperature at the surface\n",
@@ -2616,7 +2616,7 @@
     {
      "data": {
       "text/plain": [
-       "<earthkit.plots.components.maps.Map at 0x179f7cb50>"
+       "<earthkit.plots.components.maps.Map at 0x12b07cd50>"
       ]
      },
      "execution_count": 36,
@@ -2759,7 +2759,7 @@
    ],
    "source": [
     "t_res_blh = vertical.interpolate_monotonic(\n",
-    "    t, coord=h, target_coord=blh, coord_type=\"height_above_ground_level\", interpolation=\"linear\"\n",
+    "    t, coords=h, target_coords=blh, coord_type=\"height_above_ground_level\", interpolation=\"linear\"\n",
     ")\n",
     "t_res_blh.ls()"
    ]
@@ -2794,7 +2794,7 @@
     {
      "data": {
       "text/plain": [
-       "<earthkit.plots.components.figures.Figure at 0x179dbb460>"
+       "<earthkit.plots.components.figures.Figure at 0x12c2b9590>"
       ]
      },
      "execution_count": 38,

--- a/docs/tutorials/vertical/interpolate_pl_to_pl_fieldlist.ipynb
+++ b/docs/tutorials/vertical/interpolate_pl_to_pl_fieldlist.ipynb
@@ -26,7 +26,7 @@
     "tags": []
    },
    "source": [
-    "This notebook demonstrates how to interpolate GRIB fieldlist data on pressure levels to another set of pressure levels with :py:meth:`~earthkit.meteo.vertical.fieldlist.interpolate_monotonic`. We will use :ref:`earthkit-data` for fieldlist support and :ref:`earthkit-plots` for plotting."
+    "This notebook demonstrates how to interpolate GRIB fieldlist data on pressure levels to another set of pressure levels with :py:meth:`~earthkit.meteo.vertical.fieldlist.interpolate_monotonic`. We will use :xref:`earthkit-data` for fieldlist support and :ref:`xearthkit-plots` for plotting."
    ]
   },
   {
@@ -91,7 +91,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "30aaba4e38e64fa6941717ad0a6ef861",
+       "model_id": "3fab827475804883aa17c1fd7640968a",
        "version_major": 2,
        "version_minor": 0
       },
@@ -347,12 +347,15 @@
     "slideshow": {
      "slide_type": ""
     },
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "raw"
+    }
    },
    "source": [
     "We use :py:meth:`~earthkit.meteo.vertical.fieldlist.interpolate_monotonic` to carry out the interpolation. For fieldlist input it requires a distinct set of input levels, which does not need to be sorted (according to the level). \n",
     "\n",
-    ":py:meth:`~earthkit.meteo.vertical.fieldlist.interpolate_monotonic` uses the ``coord``, ``target_coord`` and ``coord_type`` arguments to specify the source and target coordinates and their shared type. "
+    "\":py:meth:`~earthkit.meteo.vertical.fieldlist.interpolate_monotonic` uses the ``coords``, ``target_coords`` and ``coord_type`` arguments to specify the source and target coordinates and their shared type. \""
    ]
   },
   {
@@ -445,7 +448,7 @@
     "coord = [f.vertical.level(units=\"Pa\") for f in t]  # Pa\n",
     "\n",
     "# define the target coordinates\n",
-    "target_coord = [87000.0, 35000.0]  # Pa\n",
+    "target_coords = [87000.0, 35000.0]  # Pa\n",
     "\n",
     "# define the coordinate type\n",
     "# (must be an earthkit-data \"vertical.level_type\")\n",
@@ -453,8 +456,8 @@
     "\n",
     "t_res = vertical.interpolate_monotonic(\n",
     "    t,  # data to interpolate\n",
-    "    coord=coord,\n",
-    "    target_coord=target_coord,\n",
+    "    coords=coord,\n",
+    "    target_coords=target_coords,\n",
     "    coord_type=coord_type,\n",
     "    interpolation=\"linear\",\n",
     ")\n",
@@ -478,7 +481,7 @@
     {
      "data": {
       "text/plain": [
-       "<earthkit.plots.components.figures.Figure at 0x12cdffb60>"
+       "<earthkit.plots.components.figures.Figure at 0x11e692cf0>"
       ]
      },
      "execution_count": 4,
@@ -546,7 +549,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b9479272a5754c4fba1032b32f360336",
+       "model_id": "b01049f802974420a61535bca21f71d1",
        "version_major": 2,
        "version_minor": 0
       },
@@ -711,8 +714,8 @@
    "source": [
     "t_res_pv = vertical.interpolate_monotonic(\n",
     "    t,\n",
-    "    coord=coord,\n",
-    "    target_coord=pres_pv,\n",
+    "    coords=coord,\n",
+    "    target_coords=pres_pv,\n",
     "    coord_type=coord_type,\n",
     "    interpolation=\"linear\",\n",
     ")\n",
@@ -750,7 +753,7 @@
     {
      "data": {
       "text/plain": [
-       "<earthkit.plots.components.figures.Figure at 0x135ad7890>"
+       "<earthkit.plots.components.figures.Figure at 0x1393a7ed0>"
       ]
      },
      "execution_count": 7,

--- a/src/earthkit/meteo/vertical/array/vertical.py
+++ b/src/earthkit/meteo/vertical/array/vertical.py
@@ -620,12 +620,12 @@ def pressure_on_hybrid_levels(
         - :math:`A_{k+1/2}` and :math:`B_{k+1/2}` are the A- and B-coefficients defining
           the model levels.
 
-    For more details see [IFS-CY49R3-Dynamics]_ Chapter 2, Section 2.2.1.
+    For more details see [IFS-CY49R1-Dynamics]_ Chapter 2, Section 2.2.1.
 
 
     Examples
     --------
-    - :ref:`/how-tos/hybrid_levels.ipynb`
+    - :ref:`/how-tos/vertical/hybrid_levels_array.ipynb`
 
     """
     if isinstance(output, str):
@@ -839,7 +839,7 @@ def _compute_relative_geopotential_thickness_on_hybrid_levels(
 
     Examples
     --------
-    - :ref:`/how-tos/hybrid_levels.ipynb`
+    - :ref:`/how-tos/vertical/hybrid_levels_array.ipynb`
 
 
     """
@@ -915,7 +915,7 @@ def relative_geopotential_thickness_on_hybrid_levels_from_alpha_delta(
 
     Examples
     --------
-    - :ref:`/how-tos/hybrid_levels.ipynb`
+    - :ref:`/how-tos/vertical/hybrid_levels_array.ipynb`
 
 
     """
@@ -1007,7 +1007,7 @@ def relative_geopotential_thickness_on_hybrid_levels(
 
     Examples
     --------
-    - :ref:`/how-tos/hybrid_levels.ipynb`
+    - :ref:`/how-tos/vertical/hybrid_levels_array.ipynb`
 
     """
     if A is None or B is None:
@@ -1112,7 +1112,7 @@ def geopotential_on_hybrid_levels(
 
     Examples
     --------
-    - :ref:`/how-tos/hybrid_levels.ipynb`
+    - :ref:`/how-tos/vertical/hybrid_levels_array.ipynb`
 
     """
     z = relative_geopotential_thickness_on_hybrid_levels(t, q, sp, A, B, vertical_dim=vertical_dim, alpha_top=alpha_top)
@@ -1210,7 +1210,7 @@ def height_on_hybrid_levels(
 
     Examples
     --------
-    - :ref:`/how-tos/hybrid_levels.ipynb`
+    - :ref:`/how-tos/vertical/hybrid_levels_array.ipynb`
 
     """
     if h_reference not in ["sea", "ground"]:
@@ -1357,7 +1357,7 @@ def interpolate_hybrid_to_pressure_levels(
 
     Examples
     --------
-    - :ref:`/how-tos/interpolate_hybrid_to_pl.ipynb`
+    - :ref:`/how-tos/vertical/interpolate_hybrid_to_pl_array.ipynb`
 
     """
     xp = array_namespace(data, A, B, sp)
@@ -1372,7 +1372,7 @@ def interpolate_hybrid_to_pressure_levels(
     return interpolate_monotonic(
         data=data,
         coords=p,
-        target_coord=target_p,
+        target_coords=target_p,
         interpolation=interpolation,
         aux_min_level_coord=aux_top_p,
         aux_min_level_data=aux_top_data,
@@ -1514,7 +1514,7 @@ def interpolate_hybrid_to_height_levels(
 
     Examples
     --------
-    - :ref:`/how-tos/interpolate_hybrid_to_hl.ipynb`
+    - :ref:`/how-tos/vertical/interpolate_hybrid_to_hl_array.ipynb`
 
     """
     h = height_on_hybrid_levels(
@@ -1533,7 +1533,7 @@ def interpolate_hybrid_to_height_levels(
     return interpolate_monotonic(
         data=data,
         coords=h,
-        target_coord=target_h,
+        target_coords=target_h,
         interpolation=interpolation,
         aux_min_level_data=aux_bottom_data,
         aux_min_level_coord=aux_bottom_h,
@@ -1645,7 +1645,7 @@ def interpolate_pressure_to_height_levels(
 
     Examples
     --------
-    - :ref:`/how-tos/interpolate_pl_to_hl.ipynb`
+    - :ref:`/how-tos/vertical/interpolate_pl_to_hl_array.ipynb`
 
     """
     if h_type == "geometric":
@@ -1661,7 +1661,7 @@ def interpolate_pressure_to_height_levels(
     return interpolate_monotonic(
         data=data,
         coords=h,
-        target_coord=target_h,
+        target_coords=target_h,
         interpolation=interpolation,
         aux_min_level_data=aux_bottom_data,
         aux_min_level_coord=aux_bottom_h,
@@ -1674,7 +1674,7 @@ def interpolate_pressure_to_height_levels(
 def interpolate_monotonic(
     data: ArrayLike,
     coords: ArrayLike,
-    target_coord: ArrayLike,
+    target_coords: ArrayLike,
     interpolation: Literal["linear", "log", "nearest"] = "linear",
     aux_min_level_data: ArrayLike | None = None,
     aux_min_level_coord: ArrayLike | None = None,
@@ -1695,12 +1695,12 @@ def interpolate_monotonic(
         shape as ``data`` or be a 1D array with length equal to the size of
         the number of levels in ``data``. Must be monotonic (either sorted
         ascending or descending) along the vertical axis.
-    target_coord : ArrayLike
+    target_coords : ArrayLike
         Target coordinate levels to which ``data`` will be interpolated. It can be
         either a scalar or a 1D array of coordinate levels. Alternatively, it can be a
         multidimensional array with a vertical axis defined by `vertical_dim`. In this case
         the other axes/dimensions must match those of ``data``. Must be the same type
-        of coordinate as ``coord``.
+        of coordinate as ``coords``.
     interpolation : {"linear", "log", "nearest"}, default="linear"
         Interpolation mode. Possible values are:
 
@@ -1732,7 +1732,7 @@ def interpolate_monotonic(
     Returns
     -------
     ArrayLike
-        Data interpolated to the target levels. The shape depends on the shape of ``target_coord``.
+        Data interpolated to the target levels. The shape depends on the shape of ``target_coords``.
         The axis corresponding to the vertical coordinate is defined by
         the ``vertical_dim`` parameter. When interpolation is not possible for a given target
         level (e.g., when the target level is outside the available level range),
@@ -1748,15 +1748,15 @@ def interpolate_monotonic(
     Notes
     -----
     - The ordering of the input coordinate levels is not checked.
-    - The units of ``coords`` and ``target_coord`` are assumed to be the same; no checks
+    - The units of ``coords`` and ``target_coords`` are assumed to be the same; no checks
       or conversions are performed.
 
     Examples
     --------
-    - :ref:`/how-tos/interpolate_hybrid_to_pl.ipynb`
-    - :ref:`/how-tos/interpolate_hybrid_to_hl.ipynb`
-    - :ref:`/how-tos/interpolate_pl_to_hl.ipynb`
-    - :ref:`/how-tos/interpolate_pl_to_pl.ipynb`
+    - :ref:`/how-tos/vertical/interpolate_hybrid_to_pl_array.ipynb`
+    - :ref:`/how-tos/vertical/interpolate_hybrid_to_hl_array.ipynb`
+    - :ref:`/how-tos/vertical/interpolate_pl_to_hl_array.ipynb`
+    - :ref:`/how-tos/vertical/interpolate_pl_to_pl_array.ipynb`
 
     """
     from .monotonic import MonotonicInterpolator
@@ -1765,7 +1765,7 @@ def interpolate_monotonic(
     return comp(
         data,
         coords,
-        target_coord,
+        target_coords,
         interpolation,
         aux_min_level_data,
         aux_min_level_coord,

--- a/src/earthkit/meteo/vertical/array/vertical.py
+++ b/src/earthkit/meteo/vertical/array/vertical.py
@@ -1371,7 +1371,7 @@ def interpolate_hybrid_to_pressure_levels(
     p = pressure_on_hybrid_levels(sp, A, B, levels=levels, alpha_top=alpha_top, output="full")
     return interpolate_monotonic(
         data=data,
-        coord=p,
+        coords=p,
         target_coord=target_p,
         interpolation=interpolation,
         aux_min_level_coord=aux_top_p,
@@ -1532,7 +1532,7 @@ def interpolate_hybrid_to_height_levels(
 
     return interpolate_monotonic(
         data=data,
-        coord=h,
+        coords=h,
         target_coord=target_h,
         interpolation=interpolation,
         aux_min_level_data=aux_bottom_data,
@@ -1660,7 +1660,7 @@ def interpolate_pressure_to_height_levels(
 
     return interpolate_monotonic(
         data=data,
-        coord=h,
+        coords=h,
         target_coord=target_h,
         interpolation=interpolation,
         aux_min_level_data=aux_bottom_data,
@@ -1673,7 +1673,7 @@ def interpolate_pressure_to_height_levels(
 
 def interpolate_monotonic(
     data: ArrayLike,
-    coord: ArrayLike,
+    coords: ArrayLike,
     target_coord: ArrayLike,
     interpolation: Literal["linear", "log", "nearest"] = "linear",
     aux_min_level_data: ArrayLike | None = None,
@@ -1690,7 +1690,7 @@ def interpolate_monotonic(
         Data to be interpolated. The axis corresponding to the vertical
         coordinate is defined by the ``vertical_dim`` parameter.
         Must have at least two levels.
-    coord : ArrayLike
+    coords : ArrayLike
         Vertical coordinates related to ``data``. Either must have the same
         shape as ``data`` or be a 1D array with length equal to the size of
         the number of levels in ``data``. Must be monotonic (either sorted
@@ -1710,20 +1710,20 @@ def interpolate_monotonic(
 
     aux_min_level_data : ArrayLike|None, optional
         Auxiliary data for interpolation to target levels below the minimum level
-        of ``coord`` and above `aux_min_level_coord`. Can be a scalar or must have
+        of ``coords`` and above `aux_min_level_coord`. Can be a scalar or must have
         the same shape as a single level of ``data``.
     aux_min_level_coord : ArrayLike|None, optional
         Coordinates of ``aux_min_level_data``. Can be a scalar or must have the same
-        shape as a single level of ``data`` or ``coord``. Must be the same type
-        of coordinate as ``coord``.
+        shape as a single level of ``data`` or ``coords``. Must be the same type
+        of coordinate as ``coords``.
     aux_max_level_data : ArrayLike|None, optional
         Auxiliary data for interpolation to target levels above the maximum level
-        of ``coord`` and below `aux_max_level_coord`. Can be a scalar or must have
+        of ``coords`` and below `aux_max_level_coord`. Can be a scalar or must have
         the same shape as a single level of ``data``.
     aux_max_level_coord : ArrayLike|None, optional
         Coordinates of ``aux_max_level_data``. Can be a scalar or must have the
-        same shape as a single level of ``data`` or ``coord``. Must be the same type
-        of coordinate as ``coord``.
+        same shape as a single level of ``data`` or ``coords``. Must be the same type
+        of coordinate as ``coords``.
     vertical_dim : int
         Axis corresponding to the vertical coordinate in the input arrays and also in the
         output array. Default is 0 (first axis).
@@ -1748,7 +1748,7 @@ def interpolate_monotonic(
     Notes
     -----
     - The ordering of the input coordinate levels is not checked.
-    - The units of ``coord`` and ``target_coord`` are assumed to be the same; no checks
+    - The units of ``coords`` and ``target_coord`` are assumed to be the same; no checks
       or conversions are performed.
 
     Examples
@@ -1764,7 +1764,7 @@ def interpolate_monotonic(
     comp = MonotonicInterpolator()
     return comp(
         data,
-        coord,
+        coords,
         target_coord,
         interpolation,
         aux_min_level_data,

--- a/src/earthkit/meteo/vertical/fieldlist/vertical.py
+++ b/src/earthkit/meteo/vertical/fieldlist/vertical.py
@@ -1264,7 +1264,7 @@ def interpolate_pressure_to_height_levels(
 
 def interpolate_monotonic(
     data: FieldList,
-    coord: ArrayLike | FieldList | None = None,
+    coords: ArrayLike | FieldList | None = None,
     target_coord: ArrayLike | FieldList | Field | None = None,
     coord_type: str | None = None,
     interpolation: Literal["linear", "log", "nearest"] = "linear",
@@ -1279,13 +1279,13 @@ def interpolate_monotonic(
     ----------
     data: FieldList
         Data to be interpolated. Must have at least two fields.
-    coord: ArrayLike | FieldList | None
+    coords: ArrayLike | FieldList | None
         Vertical coordinates related to ``data``. A valid value must be
         provided. When it is a FieldList, it must have the same number of
         fields and levels as ``data``, but the level ordering can be different.
-        The field values in ``coord`` define the vertical coordinate values for each
+        The field values in ``coords`` define the vertical coordinate values for each
         corresponding field in ``data``. The level metadata
-        is only used to pair up the fields in ``coord`` and ``data``.
+        is only used to pair up the fields in ``coords`` and ``data``.
         The vertical coordinate
         values defined in this way must be monotonic along the vertical
         axis when sorted by the level (either ascending or descending).
@@ -1296,7 +1296,7 @@ def interpolate_monotonic(
         FieldList or Field each field value provides the coordinate values the ``data``
         will be interpolated to. When provided as an ArrayLike, it must be a 1D array of
         coordinate values each defining a constant target
-        level. The values must be of the same type of coordinate as that of ``coord``.
+        level. The values must be of the same type of coordinate as that of ``coords``.
     coord_type: str | None
         Type of the coordinate levels in ``coord`` and ``target_coord``.
         The possible values are level types supported in a Field in earthkit.data.
@@ -1363,7 +1363,7 @@ def interpolate_monotonic(
     # prepare input data
     source = MonotonicData(level_type=None, sort="descending")
     source.add_profile(key="data", fl=data)
-    source.add_profile(key="coord", fl=coord, fl_template=source.data, coord=True)
+    source.add_profile(key="coord", fl=coords, fl_template=source.data, coord=True)
 
     # prepare target
     target = TargetVariable.build(

--- a/src/earthkit/meteo/vertical/fieldlist/vertical.py
+++ b/src/earthkit/meteo/vertical/fieldlist/vertical.py
@@ -1265,7 +1265,7 @@ def interpolate_pressure_to_height_levels(
 def interpolate_monotonic(
     data: FieldList,
     coords: ArrayLike | FieldList | None = None,
-    target_coord: ArrayLike | FieldList | Field | None = None,
+    target_coords: ArrayLike | FieldList | Field | None = None,
     coord_type: str | None = None,
     interpolation: Literal["linear", "log", "nearest"] = "linear",
     aux_min_level_data: float | FieldList | Field | None = None,
@@ -1291,14 +1291,14 @@ def interpolate_monotonic(
         axis when sorted by the level (either ascending or descending).
         When provided as an ArrayLike, it must be a 1D array with each value
         corresponding to the field at the same position in ``data``.
-    target_coord: ArrayLike | FieldList | Field | None
+    target_coords: ArrayLike | FieldList | Field | None
         Target coordinate levels to which ``data`` will be interpolated. When it is a
         FieldList or Field each field value provides the coordinate values the ``data``
         will be interpolated to. When provided as an ArrayLike, it must be a 1D array of
         coordinate values each defining a constant target
         level. The values must be of the same type of coordinate as that of ``coords``.
     coord_type: str | None
-        Type of the coordinate levels in ``coord`` and ``target_coord``.
+        Type of the coordinate levels in ``coord`` and ``target_coords``.
         The possible values are level types supported in a Field in earthkit.data.
         See: :py:class:`~earthkit.data.field.component.level_type.LevelType` for details.
         A valid value must be provided.
@@ -1368,13 +1368,13 @@ def interpolate_monotonic(
     # prepare target
     target = TargetVariable.build(
         key="target_coord",
-        fl=target_coord,
+        fl=target_coords,
     )
 
     # get arrays
     data_arr = source.data.to_numpy(copy=False)
     coord_arr = source.coord.to_numpy(copy=False)
-    target_coord_arr = target.fl.to_numpy(copy=False)
+    target_coords_arr = target.fl.to_numpy(copy=False)
 
     aux = {
         "aux_min_level_data": aux_min_level_data,
@@ -1391,7 +1391,7 @@ def interpolate_monotonic(
     res_arr = array.interpolate_monotonic(
         data_arr,
         coord_arr,
-        target_coord_arr,
+        target_coords_arr,
         interpolation=interpolation,
         **aux,
         vertical_dim=0,

--- a/src/earthkit/meteo/vertical/vertical.py
+++ b/src/earthkit/meteo/vertical/vertical.py
@@ -1343,8 +1343,8 @@ def interpolate_pressure_to_height_levels(
 @overload
 def interpolate_monotonic(
     data: "ArrayLike",
-    coord: "ArrayLike",
-    target_coord: "ArrayLike",
+    coords: "ArrayLike",
+    target_coords: "ArrayLike",
     interpolation: str = "linear",
     aux_min_level_data=None,
     aux_min_level_coord=None,
@@ -1357,8 +1357,8 @@ def interpolate_monotonic(
 @overload
 def interpolate_monotonic(
     data: "xarray.DataArray",
-    coord: "xarray.DataArray",
-    target_coord: "ArrayLike",
+    coords: "xarray.DataArray",
+    target_coords: "ArrayLike",
     coord_type: str | None = None,
     interpolation: str = "linear",
     vertical_dim=None,
@@ -1368,8 +1368,8 @@ def interpolate_monotonic(
 @overload
 def interpolate_monotonic(
     data: "FieldList",
-    coord: "ArrayLike | FieldList",
-    target_coord: "ArrayLike | FieldList",
+    coords: "ArrayLike | FieldList",
+    target_coords: "ArrayLike | FieldList",
     coord_type: str | None = None,
     interpolation: str = "linear",
     aux_min_level_data=None,
@@ -1382,7 +1382,7 @@ def interpolate_monotonic(
 def interpolate_monotonic(
     data: "ArrayLike | xarray.DataArray | FieldList",
     coords: "ArrayLike | xarray.DataArray | FieldList",
-    target_coord: "ArrayLike | xarray.DataArray | FieldList",
+    target_coords: "ArrayLike | xarray.DataArray | FieldList",
     coord_type: str | None = None,
     interpolation: str = "linear",
     aux_min_level_data=None,
@@ -1399,7 +1399,7 @@ def interpolate_monotonic(
         Data to be interpolated. Must have at least two fields/elements.
     coords: array-like | xarray.DataArray | FieldList
         Vertical coordinates related to ``data``.
-    target_coord: array-like | xarray.DataArray | FieldList
+    target_coords: array-like | xarray.DataArray | FieldList
         Target coordinate levels to which ``data`` will be interpolated.
     coord_type: str | None, optional
         Type of the coordinate levels. This keyword argument is not supported
@@ -1454,7 +1454,7 @@ def interpolate_monotonic(
         _kwargs["coord_type"] = coord_type
 
     return dispatch(interpolate_monotonic, xarray=True, fieldlist=True, array=True)(
-        data, coords, target_coord, **_kwargs
+        data, coords, target_coords, **_kwargs
     )
 
 
@@ -1502,7 +1502,7 @@ def interpolate_to_pressure_levels(data, p, target_p, target_p_units="Pa", inter
     )
 
 
-def interpolate_sleve_to_coord_levels(data, h, coord, target_coord, folding_mode="undef_fold", vertical_dim="z"):
+def interpolate_sleve_to_coord_levels(data, h, coord, target_coords, folding_mode="undef_fold", vertical_dim="z"):
     r"""Interpolate data from SLEVE levels to coordinate levels.
 
     Parameters
@@ -1513,7 +1513,7 @@ def interpolate_sleve_to_coord_levels(data, h, coord, target_coord, folding_mode
         SLEVE coordinate values.
     coord: xarray.DataArray
         Reference coordinate values.
-    target_coord: ArrayLike
+    target_coords: ArrayLike
         Target coordinate levels.
     folding_mode: str, optional
         Folding mode (default: "undef_fold").
@@ -1537,7 +1537,7 @@ def interpolate_sleve_to_coord_levels(data, h, coord, target_coord, folding_mode
 
     """
     return dispatch(interpolate_sleve_to_coord_levels, xarray=True, fieldlist=False, array=False)(
-        data, h, coord, target_coord, folding_mode=folding_mode, vertical_dim=vertical_dim
+        data, h, coord, target_coords, folding_mode=folding_mode, vertical_dim=vertical_dim
     )
 
 

--- a/src/earthkit/meteo/vertical/vertical.py
+++ b/src/earthkit/meteo/vertical/vertical.py
@@ -1381,7 +1381,7 @@ def interpolate_monotonic(
 
 def interpolate_monotonic(
     data: "ArrayLike | xarray.DataArray | FieldList",
-    coord: "ArrayLike | xarray.DataArray | FieldList",
+    coords: "ArrayLike | xarray.DataArray | FieldList",
     target_coord: "ArrayLike | xarray.DataArray | FieldList",
     coord_type: str | None = None,
     interpolation: str = "linear",
@@ -1397,7 +1397,7 @@ def interpolate_monotonic(
     ----------
     data: array-like | xarray.DataArray | FieldList
         Data to be interpolated. Must have at least two fields/elements.
-    coord: array-like | xarray.DataArray | FieldList
+    coords: array-like | xarray.DataArray | FieldList
         Vertical coordinates related to ``data``.
     target_coord: array-like | xarray.DataArray | FieldList
         Target coordinate levels to which ``data`` will be interpolated.
@@ -1454,7 +1454,7 @@ def interpolate_monotonic(
         _kwargs["coord_type"] = coord_type
 
     return dispatch(interpolate_monotonic, xarray=True, fieldlist=True, array=True)(
-        data, coord, target_coord, **_kwargs
+        data, coords, target_coord, **_kwargs
     )
 
 

--- a/src/earthkit/meteo/vertical/xarray/interpolation.py
+++ b/src/earthkit/meteo/vertical/xarray/interpolation.py
@@ -19,7 +19,7 @@ __all__ = [
 
 def interpolate_monotonic(
     data: xr.DataArray,
-    coord: xr.DataArray,
+    coords: xr.DataArray,
     target_coord: Sequence[float],
     coord_type: str | None = None,
     interpolation: Literal["linear", "log", "nearest"] = "linear",
@@ -32,7 +32,7 @@ def interpolate_monotonic(
     ----------
     data : xarray.DataArray
         field to interpolate
-    coord : xarray.DataArray
+    coords : xarray.DataArray
         target coordinate field data on the same levels as data
     target_coord : sequence of float
         target coordinate definition
@@ -55,7 +55,7 @@ def interpolate_monotonic(
         raise ValueError(f"Unknown interpolation: {interpolation}")
 
     # ... determine direction of target field
-    dtdz = coord.diff(vertical_dim)
+    dtdz = coords.diff(vertical_dim)
     positive = np.all(dtdz > 0).item()
 
     if not positive and not np.all(dtdz < 0):
@@ -63,7 +63,7 @@ def interpolate_monotonic(
 
     # Prepare output field field_on_target on target coordinates
     field_on_target = _init_field_with_vcoord(
-        data.broadcast_like(coord),
+        data.broadcast_like(coords),
         target_coord,
         np.nan,
         vertical_dim=vertical_dim,
@@ -71,7 +71,7 @@ def interpolate_monotonic(
 
     # Interpolate
     # ... prepare interpolation
-    tkm1 = coord.shift({vertical_dim: 1})
+    tkm1 = coords.shift({vertical_dim: 1})
     fkm1 = data.shift({vertical_dim: 1})
 
     # ... loop through target values
@@ -83,9 +83,9 @@ def interpolate_monotonic(
         # ... note that if the condition above is not fulfilled, minind will
         #     be set to k_top
         if positive:
-            t2 = coord.where((coord >= t0) & (tkm1 <= t0))
+            t2 = coords.where((coords >= t0) & (tkm1 <= t0))
         else:
-            t2 = coord.where((coord <= t0) & (tkm1 >= t0))
+            t2 = coords.where((coords <= t0) & (tkm1 >= t0))
 
         minind = t2.fillna(np.inf).argmin(dim=vertical_dim)
 

--- a/src/earthkit/meteo/vertical/xarray/interpolation.py
+++ b/src/earthkit/meteo/vertical/xarray/interpolation.py
@@ -20,7 +20,7 @@ __all__ = [
 def interpolate_monotonic(
     data: xr.DataArray,
     coords: xr.DataArray,
-    target_coord: Sequence[float],
+    target_coords: Sequence[float],
     coord_type: str | None = None,
     interpolation: Literal["linear", "log", "nearest"] = "linear",
     vertical_dim: str = "z",
@@ -34,7 +34,7 @@ def interpolate_monotonic(
         field to interpolate
     coords : xarray.DataArray
         target coordinate field data on the same levels as data
-    target_coord : sequence of float
+    target_coords : sequence of float
         target coordinate definition
     coord_type : str, optional
         type of level of the output. Currently unused.
@@ -64,7 +64,7 @@ def interpolate_monotonic(
     # Prepare output field field_on_target on target coordinates
     field_on_target = _init_field_with_vcoord(
         data.broadcast_like(coords),
-        target_coord,
+        target_coords,
         np.nan,
         vertical_dim=vertical_dim,
     )
@@ -75,7 +75,7 @@ def interpolate_monotonic(
     fkm1 = data.shift({vertical_dim: 1})
 
     # ... loop through target values
-    for target_idx, t0 in enumerate(target_coord):
+    for target_idx, t0 in enumerate(target_coords):
         # ... find the 3d field where pressure is > p0 on level k
         #     and was <= p0 on level k-1
         # ... extract the index k of the vertical layer at which p2 adopts its minimum
@@ -183,7 +183,7 @@ def interpolate_sleve_to_coord_levels(
     data: xr.DataArray,
     h: xr.DataArray,
     coord: xr.DataArray,
-    target_coord: Sequence[float],
+    target_coords: Sequence[float],
     coord_type: str | None = None,
     folding_mode: Literal["low_fold", "high_fold", "undef_fold"] = "undef_fold",
     vertical_dim: str = "z",
@@ -198,7 +198,7 @@ def interpolate_sleve_to_coord_levels(
         height on same levels as data field
     coord : xarray.DataArray
         target field on same levels as data field
-    target_coord : sequence of float
+    target_coords : sequence of float
         target coordinate values
     coord_type : str, optional
         type of level of the output. Currently unused.
@@ -226,7 +226,7 @@ def interpolate_sleve_to_coord_levels(
 
     # Prepare output field on target coordinates
     field_on_target = _init_field_with_vcoord(
-        data.broadcast_like(coord), target_coord, np.nan, vertical_dim=vertical_dim
+        data.broadcast_like(coord), target_coords, np.nan, vertical_dim=vertical_dim
     )
 
     # Interpolate
@@ -235,7 +235,7 @@ def interpolate_sleve_to_coord_levels(
     fkm1 = data.shift({vertical_dim: 1})
 
     # ... loop through tc values
-    for t_idx, t0 in enumerate(target_coord):
+    for t_idx, t0 in enumerate(target_coords):
         folding_coord_exception = xr.full_like(h[{vertical_dim: 0}], False)
         # ... find the height field where target is >= t0 on level k and was <= t0
         #     on level k-1 or where theta is <= th0 on level k

--- a/tests/vertical/fieldlist/test_vertical_grib.py
+++ b/tests/vertical/fieldlist/test_vertical_grib.py
@@ -879,7 +879,7 @@ def test_fieldlist_grib_interpolate_monotonic_pl_to_pl_scalar(sort_mode, target_
     if sort_mode[0] is not None:
         t = t.order_by({"vertical.level": sort_mode[0]})
 
-    out = vertical.interpolate_monotonic(t, coord=None, target_coord=target_coord, coord_type="pressure")
+    out = vertical.interpolate_monotonic(t, coords=None, target_coord=target_coord, coord_type="pressure")
 
     if isinstance(target_coord, (int, float)):
         target_coord = [target_coord]
@@ -942,9 +942,9 @@ def test_fieldlist_grib_interpolate_monotonic_pl_to_pl_field(sort_mode, target_i
 
     with pytest.raises(ValueError):
         # coord_type must be specified
-        vertical.interpolate_monotonic(t, coord=None, target_coord=target_coord)
+        vertical.interpolate_monotonic(t, coords=None, target_coord=target_coord)
 
-    out = vertical.interpolate_monotonic(t, coord=None, target_coord=target_coord, coord_type="pressure")
+    out = vertical.interpolate_monotonic(t, coords=None, target_coord=target_coord, coord_type="pressure")
 
     if isinstance(target_coord, Field):
         target_coord = FieldList.from_fields([target_coord])

--- a/tests/vertical/fieldlist/test_vertical_grib.py
+++ b/tests/vertical/fieldlist/test_vertical_grib.py
@@ -879,7 +879,7 @@ def test_fieldlist_grib_interpolate_monotonic_pl_to_pl_scalar(sort_mode, target_
     if sort_mode[0] is not None:
         t = t.order_by({"vertical.level": sort_mode[0]})
 
-    out = vertical.interpolate_monotonic(t, coords=None, target_coord=target_coord, coord_type="pressure")
+    out = vertical.interpolate_monotonic(t, coords=None, target_coords=target_coord, coord_type="pressure")
 
     if isinstance(target_coord, (int, float)):
         target_coord = [target_coord]
@@ -942,9 +942,9 @@ def test_fieldlist_grib_interpolate_monotonic_pl_to_pl_field(sort_mode, target_i
 
     with pytest.raises(ValueError):
         # coord_type must be specified
-        vertical.interpolate_monotonic(t, coords=None, target_coord=target_coord)
+        vertical.interpolate_monotonic(t, coords=None, target_coords=target_coord)
 
-    out = vertical.interpolate_monotonic(t, coords=None, target_coord=target_coord, coord_type="pressure")
+    out = vertical.interpolate_monotonic(t, coords=None, target_coords=target_coord, coord_type="pressure")
 
     if isinstance(target_coord, Field):
         target_coord = FieldList.from_fields([target_coord])

--- a/tests/vertical/test_array_interpolate.py
+++ b/tests/vertical/test_array_interpolate.py
@@ -233,7 +233,7 @@ def test_array_interpolate_monotonic_to_pressure_s_s_s_aux(data, coord, target_c
     # prescribe aux level at the bottom (max pressure in input is 1012 hPa)
     r = vertical.interpolate_monotonic(
         data=data,
-        coord=coord,
+        coords=coord,
         target_coord=target_coord,
         interpolation=mode,
         aux_max_level_data=1100,
@@ -265,7 +265,7 @@ def test_array_interpolate_monotonic_to_height_s_s_s_aux(data, coord, target_coo
     # prescribe aux level at the bottom (min height in input is 10.0 m)
     r = vertical.interpolate_monotonic(
         data=data,
-        coord=coord,
+        coords=coord,
         target_coord=target_coord,
         interpolation=mode,
         aux_min_level_data=0.0,
@@ -319,7 +319,7 @@ def test_array_interpolate_monotonic_to_height_a_a_a_aux(
     # prescribe aux level at the bottom
     r = vertical.interpolate_monotonic(
         data=data,
-        coord=coord,
+        coords=coord,
         target_coord=target_coord,
         interpolation=mode,
         aux_min_level_data=aux_data,

--- a/tests/vertical/test_array_interpolate.py
+++ b/tests/vertical/test_array_interpolate.py
@@ -234,7 +234,7 @@ def test_array_interpolate_monotonic_to_pressure_s_s_s_aux(data, coord, target_c
     r = vertical.interpolate_monotonic(
         data=data,
         coords=coord,
-        target_coord=target_coord,
+        target_coords=target_coord,
         interpolation=mode,
         aux_max_level_data=1100,
         aux_max_level_coord=1100,
@@ -266,7 +266,7 @@ def test_array_interpolate_monotonic_to_height_s_s_s_aux(data, coord, target_coo
     r = vertical.interpolate_monotonic(
         data=data,
         coords=coord,
-        target_coord=target_coord,
+        target_coords=target_coord,
         interpolation=mode,
         aux_min_level_data=0.0,
         aux_min_level_coord=0.0,
@@ -320,7 +320,7 @@ def test_array_interpolate_monotonic_to_height_a_a_a_aux(
     r = vertical.interpolate_monotonic(
         data=data,
         coords=coord,
-        target_coord=target_coord,
+        target_coords=target_coord,
         interpolation=mode,
         aux_min_level_data=aux_data,
         aux_min_level_coord=aux_coord,


### PR DESCRIPTION
### Description

This PR renames the following kwargs in the vertical interpolation methods:

- `coord` to `coords`
- `target_coord` to `target_coords`


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
