### PR TITLE
Improve field metadata setting

### DIFF
--- a/src/earthkit/meteo/solar/fieldlist/solar.py
+++ b/src/earthkit/meteo/solar/fieldlist/solar.py
@@ -35,7 +35,9 @@ def cos_solar_zenith_angle(
         Cosine of the solar zenith angle (clipped to be non-negative). The
         result has the same type as the input (FieldList or Field).
     """
-    out_metadata = {"parameter.variable": "cossza", "parameter.units": "1"}
+    from earthkit.meteo.utils.param import FIELD_PARAMS  # type: ignore[import]
+
+    out_metadata = FIELD_PARAMS.field_parameter_metadata("cos_solar_zenith_angle")
 
     if isinstance(data, Field):
         lat, lon = data.geography.latlons()
@@ -79,7 +81,10 @@ def cos_solar_zenith_angle_integrated(
         Time-integrated cosine of the solar zenith angle. The result has the
         same type as the input (FieldList or Field).
     """
-    out_metadata = {"parameter.variable": "cossza_integrated", "parameter.units": "1"}
+    from earthkit.meteo.utils.param import FIELD_PARAMS  # type: ignore[import]
+
+    out_metadata = FIELD_PARAMS.field_parameter_metadata("cos_solar_zenith_angle_integrated")
+
     if isinstance(data, Field):
         lat, lon = data.geography.latlons()
         v = array.cos_solar_zenith_angle_integrated(
@@ -137,7 +142,10 @@ def toa_incident_solar_radiation(
         same type as the input (FieldList or Field).
     """
     # TODO: clarify the units of the result (W/m^2 * time?) and add to metadata and docstring
-    out_metadata = {"parameter.variable": "toa_incident_solar_radiation", "parameter.units": "1"}
+    from earthkit.meteo.utils.param import FIELD_PARAMS  # type: ignore[import]
+
+    out_metadata = FIELD_PARAMS.field_parameter_metadata("toa_incident_solar_radiation")
+
     if isinstance(data, Field):
         lat, lon = data.geography.latlons()
         v = array.toa_incident_solar_radiation(

--- a/src/earthkit/meteo/thermo/fieldlist/thermo.py
+++ b/src/earthkit/meteo/thermo/fieldlist/thermo.py
@@ -42,7 +42,8 @@ def specific_humidity_from_mixing_ratio(w: FieldList | Field) -> FieldList | Fie
         q = \frac {w}{1+w}
 
     """
-    fieldlist_ufunc_kwargs = {"default": "q"}
+    fieldlist_ufunc_kwargs = {"default_variable": "specific_humidity"}
+
     return fieldlist_ufunc(array.specific_humidity_from_mixing_ratio, w, fieldlist_ufunc_kwargs=fieldlist_ufunc_kwargs)
 
 
@@ -68,7 +69,7 @@ def mixing_ratio_from_specific_humidity(q: FieldList | Field) -> FieldList | Fie
         w = \frac {q}{1-q}
 
     """
-    fieldlist_ufunc_kwargs = {"default": "w"}
+    fieldlist_ufunc_kwargs = {"default_variable": "mixing_ratio"}
     return fieldlist_ufunc(array.mixing_ratio_from_specific_humidity, q, fieldlist_ufunc_kwargs=fieldlist_ufunc_kwargs)
 
 
@@ -103,7 +104,7 @@ def vapour_pressure_from_specific_humidity(
     with :math:`\epsilon =  R_{d}/R_{v}` (see :data:`earthkit.meteo.constants.epsilon`).
 
     """
-    fieldlist_ufunc_kwargs = {"default": "vapp", "param_unit": "Pa"}
+    fieldlist_ufunc_kwargs = {"default_variable": "vapour_pressure"}
     if p is None:
         p = pressure_from_metadata(q)  # convert to Pa
 
@@ -143,7 +144,7 @@ def vapour_pressure_from_mixing_ratio(
     with :math:`\epsilon =  R_{d}/R_{v}` (see :data:`earthkit.meteo.constants.epsilon`).
 
     """
-    fieldlist_ufunc_kwargs = {"default": "vapp", "param_unit": "Pa"}
+    fieldlist_ufunc_kwargs = {"default_variable": "vapour_pressure"}
     if p is None:
         p = pressure_from_metadata(w)  # convert to Pa
 
@@ -183,7 +184,7 @@ def specific_humidity_from_vapour_pressure(
     with :math:`\epsilon = R_{d}/R_{v}` (see :data:`earthkit.meteo.constants.epsilon`).
 
     """
-    fieldlist_ufunc_kwargs = {"default": "q", "param_unit": "kg/kg"}
+    fieldlist_ufunc_kwargs = {"default_variable": "specific_humidity"}
     if p is None:
         p = pressure_from_metadata(e)  # convert to Pa
 
@@ -229,7 +230,7 @@ def mixing_ratio_from_vapour_pressure(
     with :math:`\epsilon = R_{d}/R_{v}` (see :data:`earthkit.meteo.constants.epsilon`).
 
     """
-    fieldlist_ufunc_kwargs = {"default": "w", "param_unit": "kg/kg"}
+    fieldlist_ufunc_kwargs = {"default_variable": "mixing_ratio"}
     if p is None:
         p = pressure_from_metadata(e)  # convert to Pa
 
@@ -280,7 +281,7 @@ def saturation_vapour_pressure(t: FieldList | Field, phase: str = "mixed") -> Fi
     with :math:`\alpha(t) = (\frac{t-t_{i}}{t_{0}-t_{i}})^2`.
 
     """
-    fieldlist_ufunc_kwargs = {"default": "swvp", "param_unit": "Pa"}
+    fieldlist_ufunc_kwargs = {"default_variable": "saturation_vapour_pressure"}
     return fieldlist_ufunc(
         array.saturation_vapour_pressure, t, fieldlist_ufunc_kwargs=fieldlist_ufunc_kwargs, phase=phase
     )
@@ -319,7 +320,7 @@ def saturation_mixing_ratio(
         return mixing_ratio_from_vapour_pressure(e, p)
 
     """
-    fieldlist_ufunc_kwargs = {"default": "ws", "param_unit": "kg/kg"}
+    fieldlist_ufunc_kwargs = {"default_variable": "saturation_mixing_ratio"}
 
     if p is None:
         p = pressure_from_metadata(t)  # convert to Pa
@@ -362,7 +363,7 @@ def saturation_specific_humidity(
         return specific_humidity_from_vapour_pressure(e, p)
 
     """
-    fieldlist_ufunc_kwargs = {"default": "sqw", "param_unit": "kg/kg"}
+    fieldlist_ufunc_kwargs = {"default_variable": "saturation_specific_humidity"}
     if p is None:
         p = pressure_from_metadata(t)  # convert to Pa
     return fieldlist_ufunc(
@@ -389,7 +390,7 @@ def saturation_vapour_pressure_slope(t: FieldList | Field, phase: str = "mixed")
         The result has the same type as the input ``t`` (FieldList or Field).
 
     """
-    fieldlist_ufunc_kwargs = {"default": "swvp_slope", "param_unit": "Pa/K"}
+    fieldlist_ufunc_kwargs = {"default_variable": "saturation_vapour_pressure_slope"}
     return fieldlist_ufunc(
         array.saturation_vapour_pressure_slope, t, fieldlist_ufunc_kwargs=fieldlist_ufunc_kwargs, phase=phase
     )
@@ -448,7 +449,7 @@ def saturation_mixing_ratio_slope(
         * :math:`e_{s}` is the :func:`saturation_vapour_pressure` for the given ``phase``
 
     """
-    fieldlist_ufunc_kwargs = {"default": "ws_slope", "param_unit": "kg kg-1 K-1"}
+    fieldlist_ufunc_kwargs = {"default_variable": "saturation_mixing_ratio_slope"}
     if p is None:
         p = pressure_from_metadata(t)  # convert to Pa
     return fieldlist_ufunc(
@@ -517,7 +518,7 @@ def saturation_specific_humidity_slope(
         * :math:`e_{s}` is the :func:`saturation_vapour_pressure` for the given ``phase``
 
     """
-    fieldlist_ufunc_kwargs = {"default": "sqw_slope", "param_unit": "kg kg-1 K-1"}
+    fieldlist_ufunc_kwargs = {"default_variable": "saturation_specific_humidity_slope"}
     if p is None:
         p = pressure_from_metadata(t)  # convert to Pa
 
@@ -553,7 +554,7 @@ def temperature_from_saturation_vapour_pressure(es: FieldList | Field) -> FieldL
     phase ``es`` was computed to.
 
     """
-    fieldlist_ufunc_kwargs = {"default": "t", "param_unit": "K"}
+    fieldlist_ufunc_kwargs = {"default_variable": "temperature"}
     return fieldlist_ufunc(
         array.temperature_from_saturation_vapour_pressure, es, fieldlist_ufunc_kwargs=fieldlist_ufunc_kwargs
     )
@@ -584,7 +585,7 @@ def relative_humidity_from_dewpoint(t: FieldList | Field, td: FieldList | Field)
     where :math:`e_{wsat}` is the :func:`saturation_vapour_pressure` over water.
 
     """
-    fieldlist_ufunc_kwargs = {"default": "r", "param_unit": "%"}
+    fieldlist_ufunc_kwargs = {"default_variable": "relative_humidity"}
     return fieldlist_ufunc(array.relative_humidity_from_dewpoint, t, td, fieldlist_ufunc_kwargs=fieldlist_ufunc_kwargs)
 
 
@@ -624,7 +625,7 @@ def relative_humidity_from_specific_humidity(
         * :math:`e_{msat}` is the :func:`saturation_vapour_pressure` based on the "mixed" phase
 
     """
-    fieldlist_ufunc_kwargs = {"default": "r", "param_unit": "%"}
+    fieldlist_ufunc_kwargs = {"default_variable": "relative_humidity"}
     if p is None:
         p = pressure_from_metadata(t)  # convert to Pa
     return fieldlist_ufunc(
@@ -669,7 +670,7 @@ def specific_humidity_from_dewpoint(
     Then `q` is computed from :math:`e` using :func:`specific_humidity_from_vapour_pressure`.
 
     """
-    fieldlist_ufunc_kwargs = {"default": "q", "param_unit": "kg/kg"}
+    fieldlist_ufunc_kwargs = {"default_variable": "specific_humidity"}
     if p is None:
         p = pressure_from_metadata(td)  # convert to Pa
     return fieldlist_ufunc(array.specific_humidity_from_dewpoint, td, p, fieldlist_ufunc_kwargs=fieldlist_ufunc_kwargs)
@@ -712,7 +713,7 @@ def mixing_ratio_from_dewpoint(
     Then `w` is computed from :math:`e` using :func:`mixing_ratio_from_vapour_pressure`.
 
     """
-    fieldlist_ufunc_kwargs = {"default": "w", "param_unit": "kg/kg"}
+    fieldlist_ufunc_kwargs = {"default_variable": "mixing_ratio"}
     if p is None:
         p = pressure_from_metadata(td)  # convert to Pa
     return fieldlist_ufunc(array.mixing_ratio_from_dewpoint, td, p, fieldlist_ufunc_kwargs=fieldlist_ufunc_kwargs)
@@ -753,7 +754,7 @@ def specific_humidity_from_relative_humidity(
     Then :math:`q` is computed from :math:`e` using :func:`specific_humidity_from_vapour_pressure`.
 
     """
-    fieldlist_ufunc_kwargs = {"default": "q", "param_unit": "kg/kg"}
+    fieldlist_ufunc_kwargs = {"default_variable": "specific_humidity"}
     if p is None:
         p = pressure_from_metadata(t)  # convert to Pa
     return fieldlist_ufunc(
@@ -795,16 +796,16 @@ def dewpoint_from_relative_humidity(t: FieldList | Field, r: FieldList | Field) 
 
     """
     param_ids = {
-        # 130: "td",  # atmospheric dewpoint, paramId=?
-        167: "2d",  # 2m dewpoint, paramId=168
+        130: "dewpoint",
+        167: "2m_dewpoint",
     }
 
     variables = {
-        # "t": "td",  # atmospheric dewpoint
-        "2t": "2d",  # 2m dewpoint
+        "t": "dewpoint",
+        "2t": "2m_dewpoint",
     }
 
-    fieldlist_ufunc_kwargs = {"param_ids": param_ids, "variables": variables, "default": "td"}
+    fieldlist_ufunc_kwargs = {"param_ids": param_ids, "variables": variables, "default_variable": "dewpoint"}
     return fieldlist_ufunc(array.dewpoint_from_relative_humidity, t, r, fieldlist_ufunc_kwargs=fieldlist_ufunc_kwargs)
 
 
@@ -849,18 +850,17 @@ def dewpoint_from_specific_humidity(
 
     """
     param_ids = {
-        174096: "2d",  # 2m dewpoint, paramId=168
+        174096: "2m_dewpoint",
     }
 
     variables = {
-        "2sh": "2d",  # 2m dewpoint
+        "2sh": "2m_dewpoint",
     }
 
     fieldlist_ufunc_kwargs = {
         "param_ids": param_ids,
         "variables": variables,
-        "default": "td",
-        "param_unit": "K",
+        "default_variable": "dewpoint",
     }
 
     if p is None:
@@ -893,7 +893,7 @@ def virtual_temperature(t: FieldList | Field, q: FieldList | Field) -> FieldList
     with :math:`\epsilon = R_{d}/R_{v}` (see :data:`earthkit.meteo.constants.epsilon`).
 
     """
-    fieldlist_ufunc_kwargs = {"default": "vtmp"}
+    fieldlist_ufunc_kwargs = {"default_variable": "virtual_temperature"}
     return fieldlist_ufunc(array.virtual_temperature, t, q, fieldlist_ufunc_kwargs=fieldlist_ufunc_kwargs)
 
 
@@ -934,7 +934,7 @@ def virtual_potential_temperature(
         * :math:`\epsilon = R_{d}/R_{v}` (see :data:`earthkit.meteo.constants.epsilon`).
 
     """
-    fieldlist_ufunc_kwargs = {"default": "vptmp"}
+    fieldlist_ufunc_kwargs = {"default_variable": "virtual_potential_temperature"}
 
     if p is None:
         p = pressure_from_metadata(t)  # convert to Pa
@@ -973,7 +973,7 @@ def potential_temperature(
     with :math:`\kappa = R_{d}/c_{pd}` (see :data:`earthkit.meteo.constants.kappa`).
 
     """
-    fieldlist_ufunc_kwargs = {"default": "pt"}
+    fieldlist_ufunc_kwargs = {"default_variable": "potential_temperature"}
 
     if p is None:
         p = pressure_from_metadata(t)  # convert to Pa
@@ -1012,7 +1012,7 @@ def temperature_from_potential_temperature(
     with :math:`\kappa = R_{d}/c_{pd}` (see :data:`earthkit.meteo.constants.kappa`).
 
     """
-    fieldlist_ufunc_kwargs = {"default": "t"}
+    fieldlist_ufunc_kwargs = {"default_variable": "temperature"}
 
     if p is None:
         p = pressure_from_metadata(th)
@@ -1058,7 +1058,7 @@ def pressure_on_dry_adiabat(
     with :math:`\kappa =  R_{d}/c_{pd}` (see :data:`earthkit.meteo.constants.kappa`).
 
     """
-    fieldlist_ufunc_kwargs = {"default": "pres", "param_unit": "Pa"}
+    fieldlist_ufunc_kwargs = {"default_variable": "pressure"}
 
     if p_def is None:
         p_def = pressure_from_metadata(t_def)
@@ -1104,7 +1104,7 @@ def temperature_on_dry_adiabat(
     with :math:`\kappa =  R_{d}/c_{pd}` (see :data:`earthkit.meteo.constants.kappa`).
 
     """
-    fieldlist_ufunc_kwargs = {"default": "t", "param_unit": "K"}
+    fieldlist_ufunc_kwargs = {"default_variable": "temperature"}
 
     if p_def is None:
         p_def = pressure_from_metadata(t_def)
@@ -1150,7 +1150,7 @@ def lcl_temperature(t: FieldList | Field, td: FieldList | Field, method: str = "
             t_{LCL} = 56.0 +  \frac{1}{\frac{1}{td - 56} + \frac{log(\frac{t}{td})}{800}}
 
     """
-    fieldlist_ufunc_kwargs = {"default": "t_lcl"}
+    fieldlist_ufunc_kwargs = {"default_variable": "lcl_temperature"}
     return fieldlist_ufunc(array.lcl_temperature, t, td, fieldlist_ufunc_kwargs=fieldlist_ufunc_kwargs, method=method)
 
 
@@ -1194,19 +1194,24 @@ def lcl(
     if p is None:
         p = pressure_from_metadata(t)  # convert to Pa
 
+    from earthkit.meteo.utils.param import FIELD_PARAMS
+
+    t_out_metadata = FIELD_PARAMS.field_parameter_metadata("lcl_temperature")
+    p_out_metadata = FIELD_PARAMS.field_parameter_metadata("lcl_pressure")
+
     # Handle single Field input
     if isinstance(t, ekd.Field):
         t_lcl, p_lcl = array.lcl(t.values, td.values, p.values if isinstance(p, ekd.Field) else p, method=method)
-        t_out = t.set({"values": t_lcl, "parameter.variable": "t_lcl", "parameter.units": "K"})
-        p_out = t.set({"values": p_lcl, "parameter.variable": "p_lcl", "parameter.units": "Pa"})
+        t_out = t.set({"values": t_lcl, **t_out_metadata})
+        p_out = t.set({"values": p_lcl, **p_out_metadata})
         return t_out, p_out
 
     t_result = []
     p_result = []
     for t_f, td_f, p_f in zip(t, td, p):
         t_lcl, p_lcl = array.lcl(t_f.values, td_f.values, p_f.values, method=method)
-        t_result.append(t_f.set({"values": t_lcl, "parameter.variable": "t_lcl", "parameter.units": "K"}))
-        p_result.append(t_f.set({"values": p_lcl, "parameter.variable": "p_lcl", "parameter.units": "Pa"}))
+        t_result.append(t_f.set({"values": t_lcl, **t_out_metadata}))
+        p_result.append(t_f.set({"values": p_lcl, **p_out_metadata}))
     return ekd.FieldList.from_fields(t_result), ekd.FieldList.from_fields(p_result)
 
 
@@ -1290,7 +1295,7 @@ def ept_from_dewpoint(
         * :math:`\kappa = R_{d}/c_{pd}` (see :data:`earthkit.meteo.constants.kappa`)
 
     """
-    fieldlist_ufunc_kwargs = {"default": "eqpt"}
+    fieldlist_ufunc_kwargs = {"default_variable": "eqpt"}
 
     if p is None:
         p = pressure_from_metadata(t)  # convert to Pa
@@ -1335,7 +1340,7 @@ def ept_from_specific_humidity(
     (the dewpoint is computed from q with :func:`dewpoint_from_specific_humidity`).
 
     """
-    fieldlist_ufunc_kwargs = {"default": "eqpt"}
+    fieldlist_ufunc_kwargs = {"default_variable": "eqpt"}
 
     if p is None:
         p = pressure_from_metadata(t)  # convert to Pa
@@ -1408,7 +1413,7 @@ def saturation_ept(
           (see :data:`earthkit.meteo.constants.c_pd`)
 
     """
-    fieldlist_ufunc_kwargs = {"default": "sept"}
+    fieldlist_ufunc_kwargs = {"default_variable": "sept"}
     if p is None:
         p = pressure_from_metadata(t)  # convert to Pa
     return fieldlist_ufunc(array.saturation_ept, t, p, fieldlist_ufunc_kwargs=fieldlist_ufunc_kwargs, method=method)
@@ -1454,7 +1459,7 @@ def temperature_on_moist_adiabat(
         be carried out nan is returned. The result has the same type as the input ``ept`` (FieldList or Field).
 
     """
-    fieldlist_ufunc_kwargs = {"default": "t"}
+    fieldlist_ufunc_kwargs = {"default_variable": "temperature"}
     if p is None:
         p = pressure_from_metadata(ept)  # convert to Pa
     return fieldlist_ufunc(
@@ -1514,7 +1519,7 @@ def wet_bulb_temperature_from_dewpoint(
       pressure ``p`` on the moist adiabat with the given ``t_method``.
 
     """
-    fieldlist_ufunc_kwargs = {"default": "wbgt"}
+    fieldlist_ufunc_kwargs = {"default_variable": "wet_bulb_temperature"}
     if p is None:
         p = pressure_from_metadata(t)  # convert to Pa
     return fieldlist_ufunc(
@@ -1576,7 +1581,7 @@ def wet_bulb_temperature_from_specific_humidity(
       pressure ``p`` on the moist adiabat with the given ``t_method``.
 
     """
-    fieldlist_ufunc_kwargs = {"default": "wbgt"}
+    fieldlist_ufunc_kwargs = {"default_variable": "wet_bulb_temperature"}
     if p is None:
         p = pressure_from_metadata(t)  # convert to Pa
     return fieldlist_ufunc(
@@ -1638,7 +1643,7 @@ def wet_bulb_potential_temperature_from_dewpoint(
       pressure :math:`10^{5}` Pa on the moist adiabat with the given ``t_method``.
 
     """
-    fieldlist_ufunc_kwargs = {"default": "wbgpt"}
+    fieldlist_ufunc_kwargs = {"default_variable": "wet_bulb_potential_temperature"}
     if p is None:
         p = pressure_from_metadata(t)  # convert to Pa
     return fieldlist_ufunc(
@@ -1697,7 +1702,7 @@ def wet_bulb_potential_temperature_from_specific_humidity(
     (the dewpoint is computed from q with :func:`dewpoint_from_specific_humidity`).
 
     """
-    fieldlist_ufunc_kwargs = {"default": "wbgpt"}
+    fieldlist_ufunc_kwargs = {"default_variable": "wet_bulb_potential_temperature"}
     if p is None:
         p = pressure_from_metadata(t)  # convert to Pa
     return fieldlist_ufunc(
@@ -1740,5 +1745,5 @@ def specific_gas_constant(q: FieldList | Field) -> FieldList | Field:
         * :math:`R_{v}` is the gas constant for water vapour (see :data:`earthkit.meteo.constants.Rv`)
 
     """
-    fieldlist_ufunc_kwargs = {"default": "R", "param_unit": "J kg-1 K-1"}
+    fieldlist_ufunc_kwargs = {"default_variable": "specific_gas_constant"}
     return fieldlist_ufunc(array.specific_gas_constant, q, fieldlist_ufunc_kwargs=fieldlist_ufunc_kwargs)

--- a/src/earthkit/meteo/utils/decorators.py
+++ b/src/earthkit/meteo/utils/decorators.py
@@ -251,40 +251,85 @@ def xarray_ufunc(func, *args, **kwargs):
 
 
 def field_ufunc(func, *args, **kwargs):
+    """Apply a function to the values of earthkit.data Field or FieldList objects.
+
+    Parameters
+    ----------
+    func: callable
+        The function to apply to the values of the Field or FieldList objects.
+    *args: tuple
+        The Field or FieldList objects to which the function will be applied.
+    **kwargs: dict
+        Additional keyword arguments to pass to the function. The following special keyword arguments are recognized:
+        - fieldlist_ufunc_kwargs: dict, optional
+            A dictionary of keyword arguments to pass to the function when applied to FieldList objects.
+            This can include 'variables', 'param_ids', 'default_variable'
+
+            - 'variables': dict, optional
+                A mapping of input field parameter.variable values to output parameter variable
+                names. The output parameters names must be  defined in FIELD_PARAMS.
+            - 'param_ids': dict, optional
+                A mapping of input metadata.paramId values to output parameter variable names.
+                The output parameters names must be defined in FIELD_PARAMS.
+            - 'default_variable': str, optional
+                The default parameter variable name to use if no mapping is found in
+                'variables' or 'param_ids'. This must be defined in FIELD_PARAMS.
+
+            The algorithm for determining the output parameter variable name is as follows:
+            1. If 'variables' is provided, check if the first input field's parameter.variable
+                is in the mapping. If so, use the corresponding output variable name.
+            2. If 'param_ids' is provided, check if the first input field's metadata.paramId
+                is in the mapping. If so, use the corresponding output variable name.
+            3. If neither mapping yields a result, use 'default_variable' if provided.
+            4. If no output parameter variable name can be determined, raise a ValueError.
+
+            Once the output parameter variable name is determined, the corresponding metadata
+            (parameter.variable and parameter.units) will be looked up in FIELD_PARAMS and set
+            on the resulting Field.
+    """
     import earthkit.data as ekd
 
     fieldlist_ufunc_kwargs = kwargs.pop("fieldlist_ufunc_kwargs", None) or {}
-    variables = fieldlist_ufunc_kwargs.get("variables", {})
-    param_ids = fieldlist_ufunc_kwargs.get("param_ids", {})
-    default = fieldlist_ufunc_kwargs.get("default")
-    unit = fieldlist_ufunc_kwargs.get("param_unit")
 
     fields = args
-    u0 = fields[0]
-    assert isinstance(u0, ekd.Field), "field_ufunc first argument must be a Field"
+    field = fields[0]
+    assert isinstance(field, ekd.Field), "field_ufunc first argument must be a Field"
     v = func(*(field.values if isinstance(field, ekd.Field) else field for field in fields), **kwargs)
 
-    name = None
-    var_u = u0.get("parameter.variable", default=None)
-    if var_u is not None:
-        name = variables.get(var_u)
-    else:
-        var_u = u0.get("metadata.paramId", default=None)
-        if var_u is not None:
-            name = param_ids.get(var_u)
-        else:
-            var_u = "unknown"
+    # determine the metadata to set on the resulting Field
+    variables = fieldlist_ufunc_kwargs.get("variables", {})
+    param_ids = fieldlist_ufunc_kwargs.get("param_ids", {})
+    default = fieldlist_ufunc_kwargs.get("default_variable")
 
-    if default is None:
-        default = var_u
+    name = None
+    if variables:
+        var_in = field.get("parameter.variable", default=None)
+        if var_in is not None:
+            name = variables.get(var_in)
+
+    if name is None and param_ids:
+        param_id_in = field.get("metadata.paramId", default=None)
+        if param_id_in is not None:
+            name = param_ids.get(param_id_in)
 
     if name is None:
         name = default
 
-    if unit is None:
-        unit = u0.get("parameter.units")
+    if name is None:
+        raise ValueError(
+            "Could not determine parameter name for the resulting Field. Please provide "
+            "a 'default_variable' in 'fieldlist_ufunc_kwargs'."
+        )
 
-    result = u0.set({"values": v, "parameter.variable": name, "parameter.units": unit})
+    # look up the parameter metadata from FIELD_PARAMS
+    from earthkit.meteo.utils.param import FIELD_PARAMS
+
+    param_item = FIELD_PARAMS.get(name)
+
+    if param_item is None:
+        raise ValueError(f"Unknown parameter '{name}' specified in fieldlist_ufunc_kwargs")
+    parameter_kwargs = {"parameter.variable": param_item["variable"], "parameter.units": param_item["units"]}
+    result = field.set({"values": v, **parameter_kwargs})
 
     return result
 

--- a/src/earthkit/meteo/utils/param.py
+++ b/src/earthkit/meteo/utils/param.py
@@ -7,18 +7,135 @@
 # nor does it submit to any jurisdiction.
 #
 
+"""
+Define earthkit-data Field parameter metadata.
+
+Used ffor the various meteorological parameters earthkit-meteo computes. This metadata includes:
+
+- "variable": define the Field.parameter.variable
+- "units": define the Field.parameter.units
+- "paramId": define the ecCodes GRIB parameter ID (if applicable)
+- "edition": define the ecCodes GRIB edition (if applicable)
+
+The keys of the dictionary are the names of the parameters used only internally by
+various earthkit-meteo functions.
+"""
+
 _FIELD_PARAMS = {
-    "temperature": {"variable": "t", "units": "K"},
-    "geopotential": {"variable": "z", "units": "m2/s2"},
-    "geopotential_height": {"variable": "z", "units": "m"},
-    "height": {"variable": "h", "units": "m"},
-    "pressure": {"variable": "pres", "units": "Pa"},
-    "relative_humidity": {"variable": "r", "units": "%"},
-    "pressure_full_level": {"variable": "pres", "units": "Pa"},
-    "pressure_half_level": {"variable": "pres_half", "units": "Pa"},
+    "10m_wind_direction": {"variable": "10wdir", "units": "degrees", "paramId": 260260, "edition": ("2",)},
+    "10m_wind_speed": {
+        "variable": "10si",
+        "units": "m/s",
+        "paramId": 207,
+        "edition": (
+            "1",
+            "2",
+        ),
+    },
+    "100m_wind_speed": {
+        "variable": "100si",
+        "units": "m/s",
+        "paramId": 228249,
+        "edition": (
+            "1",
+            "2",
+        ),
+    },
+    "200m_wind_speed": {
+        "variable": "200si",
+        "units": "m/s",
+        "paramId": 228241,
+        "edition": (
+            "1",
+            "2",
+        ),
+    },
+    "2m_dewpoint": {
+        "variable": "2d",
+        "units": "K",
+        "paramId": 168,
+        "edition": (
+            "1",
+            "2",
+        ),
+    },
+    "2m_relative_humidity": {
+        "variable": "2r",
+        "units": "%",
+        "paramId": 260242,
+        "edition": (
+            "1",
+            "2",
+        ),
+    },
+    "2m_specific_humidity": {
+        "variable": "2sh",
+        "units": "kg/kg",
+        "paramId": 174096,
+        "edition": (
+            "1",
+            "2",
+        ),
+    },
+    "2m_temperature": {
+        "variable": "2t",
+        "units": "K",
+        "paramId": 167,
+        "edition": (
+            "1",
+            "2",
+        ),
+    },
+    "coriolis": {"variable": "fc", "units": "1/s"},
+    "cos_solar_zenith_angle": {
+        "variable": "cossza",
+        "units": "1",
+        "paramId": 214001,
+        "edition": (
+            "1",
+            "2",
+        ),
+    },
+    "cos_solar_zenith_angle_integrated": {"variable": "cossza_integrated", "units": "1"},
+    "dewpoint": {"variable": "td", "units": "K"},
+    "eqpt": {"variable": "eqpt", "units": "K", "paramId": 4, "edition": ("1", "2")},
+    "geometric_height_above_ground": {"variable": "h", "units": "m", "paramId": 3008, "edition": ("1", "2")},
+    "geometric_height_above_sea": {"variable": "h", "units": "m"},
+    "geometric_vertical_velocity": {"variable": "wz", "units": "m/s", "paramId": 260238, "edition": ("2")},
+    "geopotential": {"variable": "z", "units": "m2/s2", "paramId": 129, "edition": ("1", "2")},
+    "geopotential_height": {"variable": "gh", "units": "gpm", "paramId": 156, "edition": ("1", "2")},
     "hybrid_alpha": {"variable": "hybrid_alpha", "units": "1"},
     "hybrid_delta": {"variable": "hybrid_delta", "units": "1"},
+    "lcl_pressure": {"variable": "p_lcl", "units": "Pa"},
+    "lcl_temperature": {"variable": "t_lcl", "units": "K"},
+    "mixing_ratio": {"variable": "mass_mixrat", "units": "kg/kg", "paramId": 402000, "edition": ("2")},
+    "potential_temperature": {"variable": "pt", "units": "K", "paramId": 3, "edition": ("1", "2")},
+    "pressure": {"variable": "pres", "units": "Pa", "paramId": 54, "edition": ("1", "2")},
+    "pressure_full_level": {"variable": "pres", "units": "Pa"},
+    "pressure_half_level": {"variable": "pres_half", "units": "Pa"},
     "relative_geopotential_thickness": {"variable": "rel_geopot_thick", "units": "m2/s2"},
+    "relative_humidity": {"variable": "r", "units": "%", "paramId": 157, "edition": ("1", "2")},
+    "saturation_mixing_ratio": {"variable": "ws", "units": "kg/kg"},
+    "saturation_mixing_ratio_slope": {"variable": "ws_slope", "units": "kg/kg/K"},
+    "saturation_specific_humidity": {"variable": "sqw", "units": "kg/kg"},
+    "saturation_specific_humidity_slope": {"variable": "sqw_slope", "units": "kg/kg/K"},
+    "saturation_vapour_pressure": {"variable": "swvp", "units": "Pa", "paramId": 261021, "edition": ("2")},
+    "saturation_vapour_pressure_slope": {"variable": "swvp_slope", "units": "Pa/K"},
+    "sept": {"variable": "sept", "units": "K", "paramId": 5, "edition": ("1", "2")},
+    "specific_gas_constant": {"variable": "R", "units": "J/kg/K"},
+    "specific_humidity": {"variable": "q", "units": "kg/kg", "paramId": 133, "edition": ("1", "2")},
+    "temperature": {"variable": "t", "units": "K", "paramId": 130, "edition": ("1", "2")},
+    "toa_incident_solar_radiation": {
+        "variable": "toa_incident_solar_radiation",
+        "units": "W/m2",
+    },
+    "vapour_pressure": {"variable": "vapp", "units": "Pa", "paramId": 260008, "edition": ("2")},
+    "virtual_potential_temperature": {"variable": "vptmp", "units": "K", "paramId": 3012, "edition": ("2")},
+    "virtual_temperature": {"variable": "vtmp", "units": "K", "paramId": 300012, "edition": ("1", "2")},
+    "wet_bulb_potential_temperature": {"variable": "wbpt", "units": "K", "paramId": 261022, "edition": ("2")},
+    "wet_bulb_temperature": {"variable": "wbgt", "units": "K", "paramId": 261014, "edition": ("2")},
+    "wind_direction": {"variable": "wdir", "units": "degrees", "paramId": 3031, "edition": ("1", "2")},
+    "wind_speed": {"variable": "ws", "units": "m/s", "paramId": 10, "edition": ("1", "2")},
 }
 
 
@@ -28,6 +145,10 @@ class _ParamDB:
 
     def get(self, name):
         return self.params[name]
+
+    def field_parameter_metadata(self, name):
+        param_item = self.get(name)
+        return {"parameter.variable": param_item["variable"], "parameter.units": param_item["units"]}
 
 
 FIELD_PARAMS = _ParamDB()

--- a/src/earthkit/meteo/vertical/fieldlist/utils.py
+++ b/src/earthkit/meteo/vertical/fieldlist/utils.py
@@ -90,7 +90,12 @@ def coord_fieldlist_from_template(fl_template=None, keep_template_shape=False):
 def to_resulting_fieldlist(arr, template=None, levels=None, vertical=None, metadata=None, param_name=""):
     metadata = metadata or {}
     if param_name:
-        metadata = {"parameter": FIELD_PARAMS.get(param_name), **metadata}
+        param_item = FIELD_PARAMS.get(param_name)
+        param_metadata = {
+            "variable": param_item["variable"],
+            "units": param_item["units"],
+        }
+        metadata = {"parameter": param_metadata, **metadata}
 
     if "vertical" in metadata:
         raise ValueError(

--- a/src/earthkit/meteo/vertical/fieldlist/vertical.py
+++ b/src/earthkit/meteo/vertical/fieldlist/vertical.py
@@ -49,7 +49,7 @@ def geopotential_height_from_geopotential(
     where :math:`g` is the gravitational acceleration on the surface of
     the Earth (see :py:attr:`earthkit.meteo.constants.g`).
     """
-    fieldlist_ufunc_kwargs = {"default": "gh", "param_unit": "gpm"}
+    fieldlist_ufunc_kwargs = {"default_variable": "geopotential_height"}
 
     return fieldlist_ufunc(
         array.geopotential_height_from_geopotential, z, fieldlist_ufunc_kwargs=fieldlist_ufunc_kwargs
@@ -83,7 +83,7 @@ def geopotential_from_geopotential_height(
     where :math:`g` is the gravitational acceleration on the surface of
     the Earth (see :py:attr:`earthkit.meteo.constants.g`).
     """
-    fieldlist_ufunc_kwargs = {"default": "z", "param_unit": "m2/s2"}
+    fieldlist_ufunc_kwargs = {"default_variable": "geopotential"}
 
     return fieldlist_ufunc(
         array.geopotential_from_geopotential_height, gh, fieldlist_ufunc_kwargs=fieldlist_ufunc_kwargs
@@ -120,7 +120,7 @@ def geopotential_height_from_geometric_height(
     where :math:`R_{earth}` is the average radius of the Earth
     (see :py:attr:`earthkit.meteo.constants.R_earth`).
     """
-    fieldlist_ufunc_kwargs = {"default": "gh", "param_unit": "gpm"}
+    fieldlist_ufunc_kwargs = {"default_variable": "geopotential_height"}
 
     return fieldlist_ufunc(
         array.geopotential_height_from_geometric_height,
@@ -164,7 +164,7 @@ def geopotential_from_geometric_height(
         * :math:`g` is the gravitational acceleration on the surface of
           the Earth (see :py:attr:`earthkit.meteo.constants.g`)
     """
-    fieldlist_ufunc_kwargs = {"default": "z", "param_unit": "m2/s2"}
+    fieldlist_ufunc_kwargs = {"default_variable": "geopotential"}
 
     return fieldlist_ufunc(
         array.geopotential_from_geometric_height,
@@ -204,7 +204,7 @@ def geometric_height_from_geopotential_height(
     where :math:`R_{earth}` is the average radius of the Earth
     (see :py:attr:`earthkit.meteo.constants.R_earth`).
     """
-    fieldlist_ufunc_kwargs = {"default": "h", "param_unit": "m"}
+    fieldlist_ufunc_kwargs = {"default_variable": "geometric_height_above_sea"}
 
     return fieldlist_ufunc(
         array.geometric_height_from_geopotential_height,
@@ -248,7 +248,7 @@ def geometric_height_from_geopotential(
         * :math:`g` is the gravitational acceleration on the surface of
           the Earth (see :py:attr:`earthkit.meteo.constants.g`)
     """
-    fieldlist_ufunc_kwargs = {"default": "h", "param_unit": "m"}
+    fieldlist_ufunc_kwargs = {"default_variable": "geometric_height_above_sea"}
 
     return fieldlist_ufunc(
         array.geometric_height_from_geopotential,
@@ -781,7 +781,16 @@ def height_on_hybrid_levels(
         t_arr, q_arr, zs_arr, sp_arr, A=A, B=B, alpha_top=alpha_top, h_type=h_type, h_reference=h_reference
     )
 
-    return source.to_fieldlist(res, template=t[0], param_name="height")
+    if h_type == "geopotential" and h_reference == "ground":
+        param_name = "geopotential_height_above_ground"
+    elif h_type == "geopotential" and h_reference == "sea":
+        param_name = "geopotential_height_above_sea"
+    elif h_type == "geometric" and h_reference == "ground":
+        param_name = "geometric_height_above_ground"
+    elif h_type == "geometric" and h_reference == "sea":
+        param_name = "geometric_height_above_sea"
+
+    return source.to_fieldlist(res, template=t[0], param_name=param_name)
 
 
 def interpolate_hybrid_to_pressure_levels(

--- a/src/earthkit/meteo/wind/fieldlist/wind.py
+++ b/src/earthkit/meteo/wind/fieldlist/wind.py
@@ -38,24 +38,24 @@ def speed(u: FieldList | Field, v: FieldList | Field) -> FieldList | Field:
         Wind speed/magnitude (same units as ``u`` and ``v``). The result has
         the same type as the input (FieldList or Field).
     """
-    param_ids = {
-        131: "ws",  # atmospheric wind, paramId=10
-        165: "10ws",  # 10m wind, paramId=207
-        228246: "100si",  # 100m wind, paramId=228249
-        228239: "200si",  # 200m wind, paramId=228241
+    variables = {
+        "u": "wind_speed",
+        "10u": "10m_wind_speed",
+        "100ua": "100m_wind_speed",
+        "200ua": "200m_wind_speed",
     }
 
-    variables = {
-        "u": "ws",  # atmospheric wind
-        "10u": "10ws",  # 10m wind
-        "100ua": "100si",  # 100m wind
-        "200ua": "200si",  # 200m wind
+    param_ids = {
+        131: "wind_speed",
+        165: "10m_wind_speed",
+        228246: "100m_wind_speed",
+        228239: "200m_wind_speed",
     }
 
     fieldlist_ufunc_kwargs = {
         "variables": variables,
         "param_ids": param_ids,
-        "default": "ws",
+        "default_variable": "wind_speed",
     }
     return fieldlist_ufunc(array.speed, u, v, fieldlist_ufunc_kwargs=fieldlist_ufunc_kwargs)
 
@@ -101,7 +101,7 @@ def direction(u: FieldList | Field, v: FieldList | Field, convention="meteo", to
 
     """
     fieldlist_ufunc_kwargs = {
-        "default": "wdir",
+        "default_variable": "wind_direction",
     }
     return fieldlist_ufunc(
         array.direction,
@@ -249,8 +249,7 @@ def w_from_omega(
         p = pressure_from_metadata(omega)  # convert to Pa
 
     fieldlist_ufunc_kwargs = {
-        "default": "wz",
-        "param_unit": "m/s",
+        "default_variable": "geometric_vertical_velocity",
     }
 
     return fieldlist_ufunc(array.w_from_omega, omega, t, p, fieldlist_ufunc_kwargs=fieldlist_ufunc_kwargs)
@@ -283,15 +282,19 @@ def coriolis(data: FieldList | Field) -> FieldList | Field:
     (see :data:`earthkit.meteo.constants.omega`) and :math:`\phi` is the latitude.
 
     """
+    from earthkit.meteo.utils.param import FIELD_PARAMS
+
+    out_metadata = FIELD_PARAMS.field_parameter_metadata("coriolis")
+
     result = []
     if isinstance(data, Field):
         lat = data.geography.latitudes()
         c = array.coriolis(lat)
-        return data.set({"values": c, "parameter.variable": "fc", "parameter.units": "1/s"})
+        return data.set({"values": c, **out_metadata})
     else:
         for field in data:
             lat = field.geography.latitudes()
             c = array.coriolis(lat)
-            result.append(field.set({"values": c, "parameter.variable": "fc", "parameter.units": "1/s"}))
+            result.append(field.set({"values": c, **out_metadata}))
 
         return FieldList.from_fields(result)

--- a/tests/thermo/fieldlist/test_thermo.py
+++ b/tests/thermo/fieldlist/test_thermo.py
@@ -186,12 +186,12 @@ def test_fieldlist_mixing_ratio_from_specific_humidity(input_type):
 
     if input_type == "fieldlist":
         assert len(out) == len(q)
-        assert out.get("parameter.variable") == ["w"] * len(q)
+        assert out.get("parameter.variable") == ["mass_mixrat"] * len(q)
         for f, vals in zip(out, SPECIFIC_HUMIDITIES):
             ref = array.mixing_ratio_from_specific_humidity(np.array(vals))
             np.testing.assert_allclose(f.values, ref)
     elif input_type == "field":
-        assert out.get("parameter.variable") == "w"
+        assert out.get("parameter.variable") == "mass_mixrat"
         ref = array.mixing_ratio_from_specific_humidity(np.array(SPECIFIC_HUMIDITIES[0]))
         np.testing.assert_allclose(out.values, ref)
 
@@ -290,13 +290,13 @@ def test_fieldlist_mixing_ratio_from_vapour_pressure(input_type, pres_type):
 
     if input_type == "fieldlist":
         assert len(out) == len(e)
-        assert out.get("parameter.variable") == ["w"] * len(e)
+        assert out.get("parameter.variable") == ["mass_mixrat"] * len(e)
         assert out.get("parameter.units") == ["kg/kg"] * len(e)
         for f, vals, p_val in zip(out, e_values, PRESSURES):
             ref = array.mixing_ratio_from_vapour_pressure(np.array(vals), np.array([p_val]))
             np.testing.assert_allclose(f.values, ref)
     elif input_type == "field":
-        assert out.get("parameter.variable") == "w"
+        assert out.get("parameter.variable") == "mass_mixrat"
         assert out.get("parameter.units") == "kg/kg"
         ref = array.mixing_ratio_from_vapour_pressure(np.array(e_values[0]), np.array([PRESSURES[0]]))
         np.testing.assert_allclose(out.values, ref)
@@ -591,13 +591,13 @@ def test_fieldlist_mixing_ratio_from_dewpoint(input_type, pres_type):
 
     if input_type == "fieldlist":
         assert len(out) == len(td)
-        assert out.get("parameter.variable") == ["w"] * len(td)
+        assert out.get("parameter.variable") == ["mass_mixrat"] * len(td)
         assert out.get("parameter.units") == ["kg/kg"] * len(td)
         for f, vals, p_val in zip(out, DEWPOINTS, PRESSURES):
             ref = array.mixing_ratio_from_dewpoint(np.array(vals), np.array([p_val]))
             np.testing.assert_allclose(f.values, ref)
     elif input_type == "field":
-        assert out.get("parameter.variable") == "w"
+        assert out.get("parameter.variable") == "mass_mixrat"
         assert out.get("parameter.units") == "kg/kg"
         ref = array.mixing_ratio_from_dewpoint(np.array(DEWPOINTS[0]), np.array([PRESSURES[0]]))
         np.testing.assert_allclose(out.values, ref)
@@ -1041,14 +1041,14 @@ def test_fieldlist_wet_bulb_potential_temperature_from_dewpoint(input_type, pres
 
     if input_type == "fieldlist":
         assert len(out) == len(t)
-        assert out.get("parameter.variable") == ["wbgpt"] * len(t)
+        assert out.get("parameter.variable") == ["wbpt"] * len(t)
         for f, v1, v2, p_val in zip(out, TEMPERATURES, DEWPOINTS, PRESSURES):
             ref = array.wet_bulb_potential_temperature_from_dewpoint(
                 np.array(v1), np.array(v2), np.array([p_val, p_val])
             )
             np.testing.assert_allclose(f.values, ref)
     elif input_type == "field":
-        assert out.get("parameter.variable") == "wbgpt"
+        assert out.get("parameter.variable") == "wbpt"
         ref = array.wet_bulb_potential_temperature_from_dewpoint(
             np.array(TEMPERATURES[0]), np.array(DEWPOINTS[0]), np.array([PRESSURES[0], PRESSURES[0]])
         )
@@ -1070,14 +1070,14 @@ def test_fieldlist_wet_bulb_potential_temperature_from_specific_humidity(input_t
 
     if input_type == "fieldlist":
         assert len(out) == len(t)
-        assert out.get("parameter.variable") == ["wbgpt"] * len(t)
+        assert out.get("parameter.variable") == ["wbpt"] * len(t)
         for f, v1, v2, p_val in zip(out, TEMPERATURES, SPECIFIC_HUMIDITIES, PRESSURES):
             ref = array.wet_bulb_potential_temperature_from_specific_humidity(
                 np.array(v1), np.array(v2), np.array([p_val])
             )
             np.testing.assert_allclose(f.values, ref)
     elif input_type == "field":
-        assert out.get("parameter.variable") == "wbgpt"
+        assert out.get("parameter.variable") == "wbpt"
         ref = array.wet_bulb_potential_temperature_from_specific_humidity(
             np.array(TEMPERATURES[0]), np.array(SPECIFIC_HUMIDITIES[0]), np.array([PRESSURES[0]])
         )

--- a/tests/thermo/fieldlist/test_thermo_grib.py
+++ b/tests/thermo/fieldlist/test_thermo_grib.py
@@ -85,7 +85,7 @@ def test_fieldlist_grib_mixing_ratio_from_specific_humidity_pl(input_type):
 
     if input_type == "fieldlist":
         assert len(out) == len(q)
-        assert (np.array(out.get("parameter.variable")) == "w").all()
+        assert (np.array(out.get("parameter.variable")) == "mass_mixrat").all()
 
     if input_type == "field":
         f = out
@@ -94,7 +94,7 @@ def test_fieldlist_grib_mixing_ratio_from_specific_humidity_pl(input_type):
 
     # field metadata
     ref_metadata = {
-        "parameter.variable": "w",
+        "parameter.variable": "mass_mixrat",
         # "metadata.shortName": "w",
         "vertical.level": 850,
         # "metadata.levelist": 850,


### PR DESCRIPTION
### Description

This PR further improves the way the output metadata is specified for the field/fieldlist based computations.

The idea is that all the field metadata keys are specified in `src/earthkit/meteo/utils/param.py`. Internally, all the computations and should use `earthkit.meteo.utils.param.FIELD_PARAMS` to define the right metadata for the field output. The keys used in`FIELD_PARAMS` are strictly internal.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
