### PR TITLE
Extend `extreme.sot` interface to include perc_tail

### DIFF
--- a/src/earthkit/meteo/extreme/array/sot.py
+++ b/src/earthkit/meteo/extreme/array/sot.py
@@ -50,7 +50,7 @@ def sot_func(qc_tail, qc, qf, eps=-1e-4, lower_bound=-10, upper_bound=10):
     return sot
 
 
-def sot(clim, ens, perc, eps=-1e4, clim_dim=0, ens_dim=0):
+def sot(clim, ens, perc, perc_tail=None, eps=-1e4, clim_dim=0, ens_dim=0):
     """Compute Shift of Tails (SOT).
 
     From climatology percentiles (sorted)
@@ -67,6 +67,8 @@ def sot(clim, ens, perc, eps=-1e4, clim_dim=0, ens_dim=0):
         Ensemble forecast. The reduction axis is set by ``ens_dim``.
     perc: int
         Percentile value (typically 10 or 90)
+    perc_tail: int
+        Percentile value for the tail (typically 1 or 99). If None, it will be set to 1 or 99 depending on ``perc``.
     eps: (float)
         Epsilon factor for zero values
     clim_dim: int
@@ -118,9 +120,9 @@ def sot(clim, ens, perc, eps=-1e4, clim_dim=0, ens_dim=0):
 
     qf = xp.percentile(ens, q=perc, axis=0)
     if perc > 50:
-        qc_tail = clim[99]
+        qc_tail = clim[perc_tail or 99]
     elif perc < 50:
-        qc_tail = clim[1]
+        qc_tail = clim[perc_tail or 1]
     else:
         raise Exception("Percentile value to be computed cannot be 50 for sot, has to be in the upper or lower half")
 
@@ -129,7 +131,7 @@ def sot(clim, ens, perc, eps=-1e4, clim_dim=0, ens_dim=0):
     return xp.reshape(sot, out_shape)
 
 
-def sot_unsorted(clim, ens, perc, eps=-1e4, clim_dim=0, ens_dim=0):
+def sot_unsorted(clim, ens, perc, perc_tail=None, eps=-1e4, clim_dim=0, ens_dim=0):
     """Compute Shift of Tails (SOT).
 
     From climatology percentiles (sorted)
@@ -146,6 +148,8 @@ def sot_unsorted(clim, ens, perc, eps=-1e4, clim_dim=0, ens_dim=0):
         Ensemble forecast. The reduction axis is set by ``ens_dim``.
     perc: int
         Percentile value (typically 10 or 90)
+    perc_tail: int
+        Percentile value for the tail (typically 1 or 99). If None, it will be set to 1 or 99 depending on ``perc``.
     eps: (float)
         Epsilon factor for zero values
     clim_dim: int
@@ -194,9 +198,9 @@ def sot_unsorted(clim, ens, perc, eps=-1e4, clim_dim=0, ens_dim=0):
     qf = xp.percentile(ens, q=perc, axis=0)
     qc = xp.percentile(clim, q=perc, axis=0)
     if perc > 50:
-        perc_tail = 99
+        perc_tail = perc_tail or 99
     elif perc < 50:
-        perc_tail = 1
+        perc_tail = perc_tail or 1
     else:
         raise Exception("Percentile value to be computed cannot be 50 for sot, has to be in the upper or lower half")
     qc_tail = xp.percentile(clim, q=perc_tail, axis=0)

--- a/src/earthkit/meteo/extreme/sot.py
+++ b/src/earthkit/meteo/extreme/sot.py
@@ -9,7 +9,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, TypeAlias, overload
+from typing import TYPE_CHECKING, Any, Optional, TypeAlias, overload
 
 from earthkit.meteo.utils.decorators import dispatch
 
@@ -24,6 +24,7 @@ def sot(
     clim: "ArrayLike",
     ens: "ArrayLike",
     perc: int,
+    perc_tail: Optional[int] = None,
     eps: float = -1e4,
     clim_dim: int | None = None,
     ens_dim: int | None = None,
@@ -35,6 +36,7 @@ def sot(
     clim: "xarray.DataArray",
     ens: "xarray.DataArray",
     perc: int,
+    perc_tail: Optional[int] = None,
     eps: float = -1e4,
     clim_dim: str | None = None,
     ens_dim: str | None = None,
@@ -45,6 +47,7 @@ def sot(
     clim,
     ens,
     perc: int,
+    perc_tail: Optional[int] = None,
     eps: float = -1e4,
     clim_dim: str | int | None = None,
     ens_dim: str | int | None = None,
@@ -59,6 +62,8 @@ def sot(
         Ensemble forecast. The reduction dimension is set by ``ens_dim``.
     perc: int
         Percentile value (typically 10 or 90)
+    perc_tail: int, optional
+        Percentile value for the tail (typically 1 or 99). If None, it will be set to 1 or 99 depending on ``perc``.
     eps: (float)
         Epsilon factor for zero values
     clim_dim: str or int, optional
@@ -82,7 +87,7 @@ def sot(
     The function returns an object of the same type as the input arguments.
     """
     dispatched = dispatch(sot, array=True)
-    return dispatched(clim, ens, perc, eps=eps, clim_dim=clim_dim, ens_dim=ens_dim)
+    return dispatched(clim, ens, perc, perc_tail=perc_tail, eps=eps, clim_dim=clim_dim, ens_dim=ens_dim)
 
 
 @overload
@@ -90,6 +95,7 @@ def sot_unsorted(
     clim: "ArrayLike",
     ens: "ArrayLike",
     perc: int,
+    perc_tail: Optional[int] = None,
     eps: float = -1e4,
     clim_dim: int | None = None,
     ens_dim: int | None = None,
@@ -101,6 +107,7 @@ def sot_unsorted(
     clim: "xarray.DataArray",
     ens: "xarray.DataArray",
     perc: int,
+    perc_tail: Optional[int] = None,
     eps: float = -1e4,
     clim_dim: str | None = None,
     ens_dim: str | None = None,
@@ -111,6 +118,7 @@ def sot_unsorted(
     clim,
     ens,
     perc: int,
+    perc_tail: Optional[int] = None,
     eps: float = -1e4,
     clim_dim: str | int | None = None,
     ens_dim: str | int | None = None,
@@ -125,6 +133,8 @@ def sot_unsorted(
         Ensemble forecast. The reduction dimension is set by ``ens_dim``.
     perc: int
         Percentile value (typically 10 or 90)
+    perc_tail: int, optional
+        Percentile value for the tail (typically 1 or 99). If None, it will be set to 1 or 99 depending on ``perc``.
     eps: (float)
         Epsilon factor for zero values
     clim_dim: str or int, optional
@@ -149,4 +159,4 @@ def sot_unsorted(
     The function returns an object of the same type as the input arguments.
     """
     dispatched = dispatch(sot_unsorted, array=True)
-    return dispatched(clim, ens, perc, eps=eps, clim_dim=clim_dim, ens_dim=ens_dim)
+    return dispatched(clim, ens, perc, perc_tail=perc_tail, eps=eps, clim_dim=clim_dim, ens_dim=ens_dim)

--- a/src/earthkit/meteo/extreme/xarray/sot.py
+++ b/src/earthkit/meteo/extreme/xarray/sot.py
@@ -9,6 +9,8 @@
 
 from __future__ import annotations
 
+from typing import Optional
+
 import xarray as xr
 
 from earthkit.meteo.utils.decorators import get_dim_from_defaults, xarray_ufunc
@@ -20,6 +22,7 @@ def sot(
     clim: xr.DataArray,
     ens: xr.DataArray,
     perc: int,
+    perc_tail: Optional[int] = None,
     eps: float = -1e4,
     clim_dim: str | None = None,
     ens_dim: str | None = None,
@@ -37,6 +40,8 @@ def sot(
         Ensemble forecast. The reduction dimension is set by ``ens_dim``.
     perc: int
         Percentile value (typically 10 or 90)
+    perc_tail: int, optional
+        Percentile value for the tail (typically 1 or 99). If None, it will be set to 1 or 99 depending on ``perc``.
     eps: (float)
         Epsilon factor for zero values
     clim_dim: str, optional
@@ -65,6 +70,7 @@ def sot(
         clim,
         ens,
         perc=perc,
+        perc_tail=perc_tail,
         eps=eps,
         clim_dim=-1,
         ens_dim=-1,
@@ -79,6 +85,7 @@ def sot_unsorted(
     clim: xr.DataArray,
     ens: xr.DataArray,
     perc: int,
+    perc_tail: Optional[int] = None,
     eps: float = -1e4,
     clim_dim: str | None = None,
     ens_dim: str | None = None,
@@ -93,6 +100,8 @@ def sot_unsorted(
         Ensemble forecast. The reduction dimension is set by ``ens_dim``.
     perc: int
         Percentile value (typically 10 or 90)
+    perc_tail: int, optional
+        Percentile value for the tail (typically 1 or 99). If None, it will be set to 1 or 99 depending on ``perc``.
     eps: (float)
         Epsilon factor for zero values
     clim_dim: str, optional
@@ -116,6 +125,7 @@ def sot_unsorted(
         clim,
         ens,
         perc=perc,
+        perc_tail=perc_tail,
         eps=eps,
         clim_dim=-1,
         ens_dim=-1,

--- a/tests/extreme/array/test_extreme.py
+++ b/tests/extreme/array/test_extreme.py
@@ -121,13 +121,16 @@ def test_np_sot(xp, device, clim, ens, v_ref):
 
 
 @pytest.mark.parametrize("xp, device", NAMESPACE_DEVICES)
-@pytest.mark.parametrize("clim, ens, v_ref", [(_data.clim_eps2, _data.ens_eps2, [np.nan])])
-def test_np_sot_perc(xp, device, clim, ens, v_ref):
+@pytest.mark.parametrize(
+    "clim, ens, perc_tail, v_ref",
+    [(_data.clim_eps2, _data.ens_eps2, None, [np.nan]), (_data.clim_eps2, _data.ens_eps2, 99, [np.nan])],
+)
+def test_np_sot_perc(xp, device, clim, ens, perc_tail, v_ref):
     clim = xp.asarray(clim, device=device)
     ens = xp.asarray(ens, device=device)
     v_ref = xp.asarray(v_ref, device=device)
 
-    sot = extreme.array.sot(clim, ens, 90, eps=1e4)
+    sot = extreme.array.sot(clim, ens, 90, perc_tail=perc_tail, eps=1e4)
 
     v_ref = xp.asarray(v_ref, dtype=sot.dtype)
 

--- a/tests/extreme/test_extreme.py
+++ b/tests/extreme/test_extreme.py
@@ -56,12 +56,20 @@ def test_np_efi_highlevel_dispatch_mixed_axis(axis):
     assert np.allclose(got, ref)
 
 
-@pytest.mark.parametrize("axis", [0, 1, 2, 3])
-def test_np_sot_highlevel_dispatch_axis(axis):
-    clim = _move_axis(_data.clim, axis)
-    ens = _move_axis(_data.ens, axis)
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"clim_dim": 0, "ens_dim": 0},
+        {"clim_dim": 3, "ens_dim": 3},
+        {"clim_dim": 0, "ens_dim": 0, "perc_tail": 99},
+        {"clim_dim": 0, "ens_dim": 0, "eps": 1e-4},
+    ],
+)
+def test_np_sot_highlevel_dispatch_axis(kwargs):
+    clim = _move_axis(_data.clim, kwargs["clim_dim"])
+    ens = _move_axis(_data.ens, kwargs["ens_dim"])
     ref = extreme.array.sot(_data.clim, _data.ens, 90)
-    got = extreme.sot(clim, ens, 90, clim_dim=axis, ens_dim=axis)
+    got = extreme.sot(clim, ens, 90, **kwargs)
     assert np.allclose(got, ref)
 
 


### PR DESCRIPTION
### Description
Allow specification of percentile tail in `extreme.sot` interface as an optional argument

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
